### PR TITLE
Make libappindicator support conditional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ PROJECT(NitrokeyApp)
 SET(PROJECT_VERSION "0.2") 
 #ADD_DEFINITIONS(-DSEAFILE_CLIENT_VERSION=${PROJECT_VERSION}) 
 
+OPTION(HAVE_LIBAPPINDICATOR "Compile support for libappindicator" YES)
+
 INCLUDE(FindPkgConfig)
 
 IF (NOT (${CMAKE_BUILD_TYPE} MATCHES Release))
@@ -145,91 +147,100 @@ ELSEIF(APPLE)
     SET( platform_specific_sources hid_mac.c)
     SET( platform_specific_libs "-framework IOKit -framework CoreFoundation")
 ELSEIF (${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "BSD")
-    pkg_check_modules(GTK2 REQUIRED gtk+-2.0)
-    SET(GTK2_INCLUDE_DIRS
-            ${GTK2_INCLUDE_DIRS}
-            /usr/include/libappindicator-0.1
-            /usr/include/gtk-2.0
-            /usr/lib/gtk-2.0/include
-            /usr/include/glib-2.0
-            /usr/lib/glib-2.0/include
-            /usr/include/cairo
-            /usr/include/atk-1.0
-            /usr/include/pango-1.0
+
+    pkg_check_modules(GTK2 gtk+-2.0)
+
+    IF (GTK2_FOUND AND HAVE_LIBAPPINDICATOR)
+
+      SET(GTK2_INCLUDE_DIRS
+          ${GTK2_INCLUDE_DIRS}
+          /usr/include/libappindicator-0.1
+          /usr/include/gtk-2.0
+          /usr/lib/gtk-2.0/include
+          /usr/include/glib-2.0
+          /usr/lib/glib-2.0/include
+          /usr/include/cairo
+          /usr/include/atk-1.0
+          /usr/include/pango-1.0
+      )
+
+      SET(EXTRA_LIBS ${GTK2_LIBRARIES} appindicator notify)
+
+      ADD_DEFINITIONS(${GTK2_CFLAGS_OTHER} -DHAVE_LIBAPPINDICATOR)
+
+    ENDIF () # GTK2_FOUND AND HAVE_LIBAPPINDICATOR
+
+    SET(EXTRA_LIBS ${EXTRA_LIBS} pthread usb-1.0)
+
+    INCLUDE_DIRECTORIES(
+      ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_BINARY_DIR}
+      ${SRCDIR}
+      ${UTILSDIR}
+      ${SRCUIDIR}
+      ${PROJECT_SOURCE_DIR}
+      ${QT_INCLUDE_DIR}
+      ${LIBUSB_INCLUDE_DIRS}
+      ${GTK2_INCLUDE_DIRS}
     )
-    SET(EXTRA_LIBS ${GTK2_LIBRARIES} pthread usb-1.0 appindicator notify)
-ENDIF()
 
-INCLUDE_DIRECTORIES(
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${SRCDIR}
-    ${UTILSDIR}
-    ${SRCUIDIR}
-    ${PROJECT_SOURCE_DIR}
-    ${QT_INCLUDE_DIR}
-    ${LIBUSB_INCLUDE_DIRS}
-    ${GTK2_INCLUDE_DIRS}
-)
+    LINK_DIRECTORIES(
+      ${QT_LIBRARY_DIR}
+      ${LIBUSB_LIBRARY_DIRS}
+      ${GTK2_LIBRARY_DIRS}
+    )
 
-LINK_DIRECTORIES(
-    ${QT_LIBRARY_DIR}
-    ${LIBUSB_LIBRARY_DIRS}
-    ${GTK2_LIBRARY_DIRS}
-)
-
-add_definitions(${GTK2_CFLAGS_OTHER})
-
+ENDIF () # WIN32
 
 # Freedesktop files
 IF(NOT WIN32)
-    install(DIRECTORY
-        #      ${CMAKE_SOURCE_DIR}/data/icons/16x16
-        #      ${CMAKE_SOURCE_DIR}/data/icons/22x22
-        #      ${CMAKE_SOURCE_DIR}/data/icons/24x24
-        #      ${CMAKE_SOURCE_DIR}/data/icons/32x32
-        #      ${CMAKE_SOURCE_DIR}/data/icons/48x48
-        #      ${CMAKE_SOURCE_DIR}/data/icons/128x128
-      ${CMAKE_SOURCE_DIR}/data/icons/
-      DESTINATION share/icons/
-    )
+  install(DIRECTORY
+      #      ${CMAKE_SOURCE_DIR}/data/icons/16x16
+      #      ${CMAKE_SOURCE_DIR}/data/icons/22x22
+      #      ${CMAKE_SOURCE_DIR}/data/icons/24x24
+      #      ${CMAKE_SOURCE_DIR}/data/icons/32x32
+      #      ${CMAKE_SOURCE_DIR}/data/icons/48x48
+      #      ${CMAKE_SOURCE_DIR}/data/icons/128x128
+    ${CMAKE_SOURCE_DIR}/data/icons/
+    DESTINATION share/icons/
+  )
 
-    install(FILES
-      ${CMAKE_SOURCE_DIR}/data/nitrokey-app.desktop
-      DESTINATION share/applications
-    )
+  install(FILES
+    ${CMAKE_SOURCE_DIR}/data/nitrokey-app.desktop
+    DESTINATION share/applications
+  )
 
-    install(FILES
-      ${CMAKE_SOURCE_DIR}/data/icons/hicolor/128x128/apps/nitrokey-app.png
-      DESTINATION share/pixmaps
-    )
+  install(FILES
+    ${CMAKE_SOURCE_DIR}/data/icons/hicolor/128x128/apps/nitrokey-app.png
+    DESTINATION share/pixmaps
+  )
 
-    # Install Nitrokey udev rules
-    install(FILES
-        ${CMAKE_SOURCE_DIR}/data/40-nitrokey.rules
-        DESTINATION /etc/udev/rules.d
-        )
+  # Install Nitrokey udev rules
+  install(FILES
+    ${CMAKE_SOURCE_DIR}/data/40-nitrokey.rules
+    DESTINATION /etc/udev/rules.d
+  )
 
-    # Install autocompletion scripts
-    install(FILES
-        ${CMAKE_SOURCE_DIR}/data//bash-autocomplete/nitrokey-app
-        DESTINATION /etc/bash_completion.d
-    )
+  # Install autocompletion scripts
+  install(FILES
+    ${CMAKE_SOURCE_DIR}/data//bash-autocomplete/nitrokey-app
+    DESTINATION /etc/bash_completion.d
+  )
 
-    install(FILES
-        ${CMAKE_SOURCE_DIR}/po/de_DE/nitrokey-app.mo
-        DESTINATION /usr/share/locale/de_DE/LC_MESSAGES
-    )
+  install(FILES
+    ${CMAKE_SOURCE_DIR}/po/de_DE/nitrokey-app.mo
+    DESTINATION /usr/share/locale/de_DE/LC_MESSAGES
+  )
 
-    install(FILES
-        ${CMAKE_SOURCE_DIR}/images/info.png
-        ${CMAKE_SOURCE_DIR}/images/quit.png
-        ${CMAKE_SOURCE_DIR}/images/safe_zahlenkreis.png
-        ${CMAKE_SOURCE_DIR}/images/settings.png
-        DESTINATION /usr/share/nitrokey
-    )
+  install(FILES
+    ${CMAKE_SOURCE_DIR}/images/info.png
+    ${CMAKE_SOURCE_DIR}/images/quit.png
+    ${CMAKE_SOURCE_DIR}/images/safe_zahlenkreis.png
+    ${CMAKE_SOURCE_DIR}/images/settings.png
+    DESTINATION /usr/share/nitrokey
+  )
 
-ENDIF()
+ENDIF () # NOT WIN32
 
 
 ADD_EXECUTABLE(nitrokey-app ${GUI_TYPE}

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -98,7 +98,7 @@ class OwnSleep:public QThread
 #define LOCAL_PASSWORD_SIZE         40
 
 
-#ifdef Q_OS_LINUX
+#ifdef HAVE_LIBAPPINDICATOR
 /*
  * Indicator call backs
  */
@@ -378,11 +378,11 @@ QString desktop = getenv ("XDG_CURRENT_DESKTOP");
     return (desktop.toLower () == "unity" || desktop.toLower () == "kde" || desktop.toLower () == "lxde" || desktop.toLower () == "xfce");
 }
 
-#endif // Q_OS_LINUX
+#endif // HAVE_LIBAPPINDICATOR
 
 void MainWindow::showTrayMessage (const QString & title, const QString & msg, enum trayMessageType type, int timeout)
 {
-#ifdef Q_OS_LINUX
+#ifdef HAVE_LIBAPPINDICATOR
     if (isUnity ())
     {
         if (!notify_init ("example"))
@@ -395,7 +395,7 @@ void MainWindow::showTrayMessage (const QString & title, const QString & msg, en
         notify_uninit ();
     }
     else
-#endif // Q_OS_LINUX
+#endif // HAVE_LIBAPPINDICATOR
     {
         if (TRUE == trayIcon->supportsMessages ())
         {
@@ -425,14 +425,14 @@ void MainWindow::showTrayMessage (const QString & title, const QString & msg, en
  */
 void MainWindow::createIndicator ()
 {
-#ifdef Q_OS_LINUX
+#ifdef HAVE_LIBAPPINDICATOR
     if (isUnity ())
     {
         indicator = app_indicator_new ("Nitrokey App", "nitrokey-app", APP_INDICATOR_CATEGORY_OTHER);
         app_indicator_set_status (indicator, APP_INDICATOR_STATUS_ACTIVE);
     }
     else    // other DE's and OS's
-#endif // Q_OS_LINUX
+#endif // HAVE_LIBAPPINDICATOR
     {
         trayIcon = new QSystemTrayIcon (this);
         trayIcon->setIcon (QIcon (":/images/CS_icon.png"));
@@ -1056,7 +1056,7 @@ int i;
 
 void MainWindow::generateMenu ()
 {
-#ifdef Q_OS_LINUX
+#ifdef HAVE_LIBAPPINDICATOR
     if (isUnity ())
     {
         indicatorMenu = gtk_menu_new ();
@@ -1109,7 +1109,7 @@ GtkWidget* separItem = gtk_separator_menu_item_new ();
         app_indicator_set_menu (indicator, GTK_MENU (indicatorMenu));
     }
     else
-#endif // Q_OS_LINUX
+#endif // HAVE_LIBAPPINDICATOR
     {
         if (NULL == trayMenu)
             trayMenu = new QMenu ();
@@ -1270,7 +1270,7 @@ void MainWindow::initActionsForStick20 ()
 
 void MainWindow::generatePasswordMenu ()
 {
-#ifdef Q_OS_LINUX
+#ifdef HAVE_LIBAPPINDICATOR
     if (isUnity ())
     {
 GtkWidget* passwordsItem = gtk_menu_item_new_with_label (_("Passwords"));
@@ -1346,7 +1346,7 @@ struct getOTPData* otp_data;
         gtk_widget_show (separItem1);
     }
     else
-#endif // Q_OS_LINUX
+#endif // HAVE_LIBAPPINDICATOR
     {
         trayMenuPasswdSubMenu = trayMenu->addMenu (tr ("Passwords"));
 
@@ -1434,7 +1434,7 @@ struct getOTPData* otp_data;
 
 void MainWindow::generateMenuForProDevice ()
 {
-#ifdef Q_OS_LINUX
+#ifdef HAVE_LIBAPPINDICATOR
     if (isUnity ())
     {
 GtkWidget* configureItem = gtk_image_menu_item_new_with_label (_("Configure"));
@@ -1497,7 +1497,7 @@ GtkWidget* configureSubMenu = gtk_menu_new ();
         gtk_widget_show (configureSubMenu);
     }
     else
-#endif // Q_OS_LINUX
+#endif // HAVE_LIBAPPINDICATOR
     {
         generatePasswordMenu ();
         trayMenu->addSeparator ();
@@ -1537,7 +1537,7 @@ void MainWindow::generateMenuForStorageDevice ()
 {
 int AddSeperator = FALSE;
 
-#ifdef Q_OS_LINUX
+#ifdef HAVE_LIBAPPINDICATOR
     if (isUnity ())
     {
 GtkWidget* updateStorageStatusItem = gtk_menu_item_new_with_label (_("Smartcard or SD card are not ready"));
@@ -1753,7 +1753,7 @@ GtkWidget* extendedConfigureSubMenu = gtk_menu_new ();
         gtk_widget_show (separItem2);
     }
     else
-#endif // Q_OS_LINUX
+#endif // HAVE_LIBAPPINDICATOR
     {
 
         if (FALSE == Stick20ScSdCardOnline) // Is Stick 2.0 online (SD + SC
@@ -3975,7 +3975,7 @@ void MainWindow::generateMenuPasswordSafe ()
 {
     if (FALSE == cryptostick->passwordSafeUnlocked)
     {
-#ifdef Q_OS_LINUX
+#ifdef HAVE_LIBAPPINDICATOR
         if (isUnity ())
         {
             GtkWidget* passwordSafeItem = gtk_image_menu_item_new_with_label (_("Unlock password safe"));
@@ -3988,7 +3988,7 @@ void MainWindow::generateMenuPasswordSafe ()
             gtk_widget_show (passwordSafeItem);
         }
         else
-#endif // Q_OS_LINUX
+#endif // HAVE_LIBAPPINDICATOR
         {
             trayMenu->addAction (UnlockPasswordSafeAction);
 

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -30,7 +30,7 @@
 
 #define TRAY_MSG_TIMEOUT    5000
 
-#ifdef Q_OS_LINUX
+#ifdef HAVE_LIBAPPINDICATOR
 #undef signals
 extern "C"
 {
@@ -39,7 +39,7 @@ extern "C"
 #include <gtk/gtk.h>
 }
 #define signals public
-#endif // Q_OS_LINUX
+#endif // HAVE_LIBAPPINDICATOR
 
 
 namespace Ui
@@ -94,10 +94,10 @@ class MainWindow:public QMainWindow
     void showTrayMessage (const QString & title, const QString & msg, enum trayMessageType type, int timeout);
 
       Ui::MainWindow * ui;
-#ifdef Q_OS_LINUX
+#ifdef HAVE_LIBAPPINDICATOR
     AppIndicator* indicator;
     GtkWidget* indicatorMenu;
-#endif // Q_OS_LINUX
+#endif // HAVE_LIBAPPINDICATOR
     QSystemTrayIcon* trayIcon;
     QMenu* trayMenu;
     QMenu* trayMenuSubConfigure;

--- a/src/ui/stick20-response-task.cpp
+++ b/src/ui/stick20-response-task.cpp
@@ -21,14 +21,14 @@
 #include "stick20-response-task.h"
 #include "stick20responsedialog.h"
 
-#ifdef Q_OS_LINUX
+#ifdef HAVE_LIBAPPINDICATOR
 #undef signals
 extern "C"
 {
 #include <libnotify/notify.h>
 }
 #define signals public
-#endif // Q_OS_LINUX
+#endif // HAVE_LIBAPPINDICATOR
 
 // #include "ui_stick20-response-task.h"
 
@@ -86,7 +86,7 @@ void Stick20ResponseTask::ShowIconMessage (const QString msg)
 {
     QString title = QString ("Nitrokey App");
     int timeout = 3000;
-#ifdef Q_OS_LINUX
+#ifdef HAVE_LIBAPPINDICATOR
     if (isUnity ())
     {
         if (!notify_init ("example"))
@@ -99,7 +99,7 @@ void Stick20ResponseTask::ShowIconMessage (const QString msg)
         notify_uninit ();
     }
     else
-#endif // Q_OS_LINUX
+#endif // HAVE_LIBAPPINDICATOR
     {
         if (TRUE == trayIcon->supportsMessages ())
         {


### PR DESCRIPTION
Make libappindicator support conditional. By default it is enabled. But now you can do "cmake -DHAVE_LIBAPPINDICATOR=NO ." to disable it. I've tested the program only with Qt5 support on Linux. It compiles and run without problem.

	modified:   CMakeLists.txt
	modified:   src/ui/mainwindow.cpp
	modified:   src/ui/mainwindow.h
	modified:   src/ui/stick20-response-task.cpp