### PR TITLE
Workaround for issue 43

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,12 @@ void HelpInfos (void)
 
 int main (int argc, char* argv[])
 {
-    // Q_INIT_RESOURCE(stylesheet);
+    //workaround for issue https://github.com/Nitrokey/nitrokey-app/issues/43
+#if QT_VERSION > QT_VERSION_CHECK(5, 0, 0)
+    if (qgetenv("QT_QPA_PLATFORMTHEME") == "appmenu-qt5"){
+        qputenv("QT_QPA_PLATFORMTHEME","generic");
+    }
+#endif
 
     csApplet = new CryptostickApplet;
 


### PR DESCRIPTION
This is workaround for issue #43. It sets QT_QPA_PLATFORMTHEME to generic for local process if appmenu is detected within same variable. It should be sufficient for now. Bug is identified in Appmenu-qt5 and should be fixed within next versions of Ubuntu and / or it's package updates.
Fix works with Ubuntu 16.04 and Unity.

To cite from 'https://github.com/owncloud/client/issues/4693':

> Appmenu-qt5 is dead, and we want to remove it from Ubuntu as soon as our Qt is updated to 5.6 (which has native support for D-Bus trays and global menus). However, provided that 16.04 is an LTS release, it may make sense to get the appmenu-qt5 bug fixed there. I will add it to my list, however I have very few time, so I don't know when I will be able to get to it. Merge proposals against lp:appmenu-qt5 welcome, of course :)