### PR TITLE
Correcting solution for issue #45

### DIFF
--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -188,7 +188,7 @@ public slots:
   void getTOTPDialog(int slot);
   void getHOTPDialog(int slot);
   void PWS_ExceClickedSlot(int Slot);
-  void startStick20DestroyCryptedVolume();
+  void startStick20DestroyCryptedVolume(int fillSDWithRandomChars);
   void startStick20FillSDCardWithRandomChars();
   void startStick20EnableCryptedVolume();
   void startStick20DisableCryptedVolume();


### PR DESCRIPTION
Correcting solution for issue #45
Command "destroy encrypted data" should not initialize the storage with random data

Need to be tested yet.