### PR TITLE
Issue 38 no feedback after changing password

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -2244,11 +2244,9 @@ bool Device::stick20EnableCryptedPartition(uint8_t *password) {
   cmd = new Command(STICK20_CMD_ENABLE_CRYPTED_PARI, password, n);
   res = sendCommand(cmd);
 
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
-
-  return (true);
+  return success;
 }
 
 /*******************************************************************************
@@ -2269,11 +2267,9 @@ bool Device::stick20DisableCryptedPartition(void) {
   cmd = new Command(STICK20_CMD_DISABLE_CRYPTED_PARI, NULL, 0);
   res = sendCommand(cmd);
 
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
-
-  return (true);
+  return success;
 }
 
 /*******************************************************************************
@@ -2302,11 +2298,9 @@ bool Device::stick20EnableHiddenCryptedPartition(uint8_t *password) {
 
   cmd = new Command(STICK20_CMD_ENABLE_HIDDEN_CRYPTED_PARI, password, n);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
-
-  return (true);
+  return success;
 }
 
 /*******************************************************************************
@@ -2326,11 +2320,9 @@ bool Device::stick20DisableHiddenCryptedPartition(void) {
 
   cmd = new Command(STICK20_CMD_DISABLE_HIDDEN_CRYPTED_PARI, NULL, 0);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
-
-  return (true);
+  return success;
 }
 
 /*******************************************************************************
@@ -2358,11 +2350,10 @@ bool Device::stick20EnableFirmwareUpdate(uint8_t *password) {
 
   cmd = new Command(STICK20_CMD_ENABLE_FIRMWARE_UPDATE, password, n);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
+  return success;
 
-  return (true);
 }
 
 bool Device::stick20NewUpdatePassword(uint8_t *old_password, uint8_t *new_password) {
@@ -2417,11 +2408,10 @@ bool Device::stick20ExportFirmware(uint8_t *password) {
 
   cmd = new Command(STICK20_CMD_EXPORT_FIRMWARE_TO_FILE, password, n);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
+  return success;
 
-  return (true);
 }
 
 /*******************************************************************************
@@ -2449,11 +2439,10 @@ bool Device::stick20CreateNewKeys(uint8_t *password) {
 
   cmd = new Command(STICK20_CMD_GENERATE_NEW_KEYS, password, n);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
+  return success;
 
-  return (true);
 }
 
 /*******************************************************************************
@@ -2487,11 +2476,10 @@ bool Device::stick20FillSDCardWithRandomChars(uint8_t *password, uint8_t VolumeF
 
   cmd = new Command(STICK20_CMD_FILL_SD_CARD_WITH_RANDOM_CHARS, data, n + 1);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
+  return success;
 
-  return (true);
 }
 
 /*******************************************************************************
@@ -2511,11 +2499,10 @@ bool Device::stick20SetupHiddenVolume(void) {
 
   cmd = new Command(STICK20_CMD_SEND_HIDDEN_VOLUME_SETUP, NULL, 0);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
+  return success;
 
-  return (true);
 }
 
 /*******************************************************************************
@@ -2535,11 +2522,10 @@ bool Device::stick20GetPasswordMatrix(void) {
 
   cmd = new Command(STICK20_CMD_SEND_PASSWORD_MATRIX, NULL, 0);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
+  return success;
 
-  return (true);
 }
 
 /*******************************************************************************
@@ -2568,11 +2554,10 @@ bool Device::stick20SendPasswordMatrixPinData(uint8_t *Pindata) {
 
   cmd = new Command(STICK20_CMD_SEND_PASSWORD_MATRIX_PINDATA, Pindata, n);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
+  return success;
 
-  return (true);
 }
 
 /*******************************************************************************
@@ -2600,11 +2585,10 @@ bool Device::stick20SendPasswordMatrixSetup(uint8_t *Setupdata) {
 
   cmd = new Command(STICK20_CMD_SEND_PASSWORD_MATRIX_SETUP, Setupdata, n);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
+  return success;
 
-  return (true);
 }
 
 /*******************************************************************************
@@ -2626,11 +2610,10 @@ bool Device::stick20GetStatusData() {
 
   cmd = new Command(STICK20_CMD_GET_DEVICE_STATUS, NULL, 0);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
+  return success;
 
-  return (true);
 }
 
 bool Device::stick20SendPassword(uint8_t *Pindata) {
@@ -2698,11 +2681,10 @@ int Device::stick20SendSetReadonlyToUncryptedVolume(uint8_t *Pindata) {
 
   cmd = new Command(STICK20_CMD_ENABLE_READONLY_UNCRYPTED_LUN, Pindata, n);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
+  return success;
 
-  return (true);
 }
 
 /*******************************************************************************
@@ -2731,11 +2713,10 @@ int Device::stick20SendSetReadwriteToUncryptedVolume(uint8_t *Pindata) {
 
   cmd = new Command(STICK20_CMD_ENABLE_READWRITE_UNCRYPTED_LUN, Pindata, n);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
+  return success;
 
-  return (true);
 }
 
 /*******************************************************************************
@@ -2767,11 +2748,10 @@ int Device::stick20SendClearNewSdCardFound(uint8_t *Pindata) {
 
   cmd = new Command(STICK20_CMD_CLEAR_NEW_SD_CARD_FOUND, Pindata, n);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
+  return success;
 
-  return (true);
 }
 
 /*******************************************************************************
@@ -2798,11 +2778,10 @@ int Device::stick20SendStartup(uint64_t localTime) {
 
   cmd = new Command(STICK20_CMD_SEND_STARTUP, data, 8);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
+  return success;
 
-  return (TRUE);
 }
 
 /*******************************************************************************
@@ -2831,11 +2810,10 @@ int Device::stick20SendHiddenVolumeSetup(HiddenVolumeSetup_tst *HV_Data_st) {
 
   cmd = new Command(STICK20_CMD_SEND_HIDDEN_VOLUME_SETUP, data, sizeof(HiddenVolumeSetup_tst));
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
+  return success;
 
-  return (TRUE);
 }
 
 /*******************************************************************************
@@ -2866,11 +2844,10 @@ int Device::stick20LockFirmware(uint8_t *password) {
 
   cmd = new Command(STICK20_CMD_SEND_LOCK_STICK_HARDWARE, password, n);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
+  return success;
 
-  return (true);
 }
 
 /*******************************************************************************
@@ -2899,11 +2876,10 @@ int Device::stick20ProductionTest(void) {
 
   cmd = new Command(STICK20_CMD_PRODUCTION_TEST, TestData, n);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
+  return success;
 
-  return (true);
 }
 
 /*******************************************************************************
@@ -2932,11 +2908,10 @@ int Device::stick20GetDebugData(void) {
 
   cmd = new Command(STICK20_CMD_SEND_DEBUG_DATA, TestData, n);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  bool success = res > 0;
   delete cmd;
+  return success;
 
-  return (true);
 }
 
 /*******************************************************************************

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -2662,54 +2662,29 @@ bool Device::stick20GetStatusData() {
   return (true);
 }
 
-/*******************************************************************************
-
-  stick20SendPassword
-
-  Reviews
-  Date      Reviewer        Info
-  13.08.13  RB              First review
-
-*******************************************************************************/
-
-int Device::stick20SendPassword(uint8_t *Pindata) {
+bool Device::stick20SendPassword(uint8_t *Pindata) {
   uint8_t n;
-
-  int res;
-
+  bool success;
   Command *cmd;
 
   // Check pin data length
   n = strlen((const char *)Pindata);
   if (STICK20_PASSOWRD_LEN + 2 <= n) // Kind byte + End byte 0
   {
-    return (false);
+    return false;
   }
 
   cmd = new Command(STICK20_CMD_SEND_PASSWORD, Pindata, n);
-  res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  success = sendCommand(cmd) > 0;
   delete cmd;
 
-  return (true);
+  return success;
 }
 
-/*******************************************************************************
-
-  stick20SendNewPassword
-
-  Reviews
-  Date      Reviewer        Info
-  13.08.13  RB              First review
-
-*******************************************************************************/
-
-int Device::stick20SendNewPassword(uint8_t *NewPindata) {
+// FIXME stick20SendNewPassword is a duplicate of stick20SendPassword
+bool Device::stick20SendNewPassword(uint8_t *NewPindata) {
   uint8_t n;
-
-  int res;
-
+  int success;
   Command *cmd;
 
   // Check pin data length
@@ -2720,12 +2695,10 @@ int Device::stick20SendNewPassword(uint8_t *NewPindata) {
   }
 
   cmd = new Command(STICK20_CMD_SEND_NEW_PASSWORD, NewPindata, n);
-  res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
+  success = sendCommand(cmd) > 0;
   delete cmd;
 
-  return (true);
+  return success;
 }
 
 /*******************************************************************************

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -2389,7 +2389,7 @@ bool Device::stick20NewUpdatePassword(uint8_t *old_password, uint8_t *new_passwo
   res = sendCommand(cmd);
   delete cmd;
 
-  return res >0;
+  return res > 0;
 }
 
 /*******************************************************************************

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -2365,24 +2365,10 @@ bool Device::stick20EnableFirmwareUpdate(uint8_t *password) {
   return (true);
 }
 
-/*******************************************************************************
-
-  stick20EnableFirmwareUpdate
-
-  21.06.15  RB              First review
-
-  Reviews
-  Date      Reviewer        Info
-
-*******************************************************************************/
-
 bool Device::stick20NewUpdatePassword(uint8_t *old_password, uint8_t *new_password) {
   uint8_t n;
-
   int res;
-
   uint8_t SendString[33];
-
   Command *cmd;
 
   // Check password length
@@ -2401,11 +2387,9 @@ bool Device::stick20NewUpdatePassword(uint8_t *old_password, uint8_t *new_passwo
           CS20_MAX_UPDATE_PASSWORD_LEN);
   cmd = new Command(STICK20_CMD_CHANGE_UPDATE_PIN, SendString, 33);
   res = sendCommand(cmd);
-  if (res) {
-  } // Fix warnings
   delete cmd;
 
-  return (true);
+  return res >0;
 }
 
 /*******************************************************************************

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -1846,25 +1846,12 @@ int Device::userAuthorize(Command *authorizedCmd) {
   return -1;
 }
 
-/*******************************************************************************
-
-  unlockUserPassword
-
-  Changes
-  Date      Author        Info
-  02.09.14  RB            Function created
-
-  Reviews
-  Date      Reviewer        Info
-
-*******************************************************************************/
-
+// returns 0 on success
 int Device::unlockUserPassword(uint8_t *adminPassword) {
   int res;
 
   if (isConnected) {
     Command *cmd = new Command(CMD_UNLOCK_USER_PASSWORD, adminPassword, STICK20_PASSOWRD_LEN + 2);
-
     res = sendCommand(cmd);
 
     if (res == -1) {

--- a/src/device.h
+++ b/src/device.h
@@ -348,8 +348,8 @@ public:
   bool stick20SendPasswordMatrixPinData(uint8_t *Pindata);
   bool stick20SendPasswordMatrixSetup(uint8_t *Setupdata);
   bool stick20GetStatusData();
-  int stick20SendPassword(uint8_t *Pindata);
-  int stick20SendNewPassword(uint8_t *NewPindata);
+  bool stick20SendPassword(uint8_t *Pindata);
+  bool stick20SendNewPassword(uint8_t *NewPindata);
   int stick20SendClearNewSdCardFound(uint8_t *Pindata);
 
   int stick20SendSetReadonlyToUncryptedVolume(uint8_t *Pindata);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2779,8 +2779,12 @@ int MainWindow::stick20SendCommand(uint8_t stick20Command, uint8_t *password) {
   switch (stick20Command) {
   case STICK20_CMD_ENABLE_CRYPTED_PARI:
     ret = cryptostick->stick20EnableCryptedPartition(password);
-    if (TRUE == ret)
+    if (TRUE == ret) {
       waitForAnswerFromStick20 = TRUE;
+    } else {
+      csApplet->warningBox(
+          tr("There was an error during communicating with device. Please try again."));
+    }
     break;
   case STICK20_CMD_DISABLE_CRYPTED_PARI:
     ret = cryptostick->stick20DisableCryptedPartition();
@@ -2789,8 +2793,12 @@ int MainWindow::stick20SendCommand(uint8_t stick20Command, uint8_t *password) {
     break;
   case STICK20_CMD_ENABLE_HIDDEN_CRYPTED_PARI:
     ret = cryptostick->stick20EnableHiddenCryptedPartition(password);
-    if (TRUE == ret)
+    if (TRUE == ret) {
       waitForAnswerFromStick20 = TRUE;
+    } else {
+      csApplet->warningBox(
+          tr("There was an error during communicating with device. Please try again."));
+    }
     break;
   case STICK20_CMD_DISABLE_HIDDEN_CRYPTED_PARI:
     ret = cryptostick->stick20DisableHiddenCryptedPartition();
@@ -2893,7 +2901,6 @@ int MainWindow::stick20SendCommand(uint8_t stick20Command, uint8_t *password) {
   Result = FALSE;
   if (TRUE == waitForAnswerFromStick20) {
     Stick20ResponseTask ResponseTask(this, cryptostick, trayIcon);
-
     if (FALSE == stopWhenStatusOKFromStick20)
       ResponseTask.NoStopWhenStatusOK();
     ResponseTask.GetResponse();
@@ -2958,6 +2965,9 @@ int MainWindow::stick20SendCommand(uint8_t stick20Command, uint8_t *password) {
     default:
       break;
     }
+  } else {
+    csApplet->warningBox(tr("Either the password is not correct or the command execution resulted "
+                            "in an error. Please try again."));
   }
   return (true);
 }

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2237,19 +2237,15 @@ void MainWindow::startStickDebug() {
 }
 
 void MainWindow::startAboutDialog() {
-  AboutDialog dialog(cryptostick, this);
-
   if (TRUE == cryptostick->activStick20) {
     // Get actual data from stick 20
     cryptostick->stick20GetStatusData();
-
     Stick20ResponseTask ResponseTask(this, cryptostick, trayIcon);
-
     ResponseTask.NoStopWhenStatusOK();
     ResponseTask.GetResponse();
-
     UpdateDynamicMenuEntrys(); // Use new data to update menu
   }
+  AboutDialog dialog(cryptostick, this);
   dialog.exec();
 }
 

--- a/src/ui/stick20changepassworddialog.cpp
+++ b/src/ui/stick20changepassworddialog.cpp
@@ -104,28 +104,30 @@ void DialogChangePassword::InitData(void) {
   switch (PasswordKind) {
   case STICK20_PASSWORD_KIND_USER:
   case STICK10_PASSWORD_KIND_USER:
-    ui->label_2->setText(tr("Old user PIN"));
-    ui->label_3->setText(tr("New user PIN"));
-    ui->label_4->setText(tr("New user PIN"));
+    this->setWindowTitle(tr("Set User PIN"));
+    ui->label_2->setText(tr("Current User PIN:"));
+    ui->label_3->setText(tr("New User PIN:"));
+    ui->label_4->setText(tr("New User PIN:"));
     break;
   case STICK20_PASSWORD_KIND_ADMIN:
   case STICK10_PASSWORD_KIND_ADMIN:
-    ui->label_2->setText(tr("Admin PIN"));
-    ui->label_3->setText(tr("New admin PIN"));
-    ui->label_4->setText(tr("New admin PIN"));
+    this->setWindowTitle(tr("Set Admin PIN"));
+    ui->label_2->setText(tr("Current Admin PIN:"));
+    ui->label_3->setText(tr("New Admin PIN:"));
+    ui->label_4->setText(tr("New Admin PIN:"));
     break;
   case STICK20_PASSWORD_KIND_RESET_USER:
   case STICK10_PASSWORD_KIND_RESET_USER:
-    this->setWindowTitle(tr("Reset user PIN"));
+    this->setWindowTitle(tr("Reset User PIN"));
     ui->label_2->setText(tr("Admin PIN:"));
-    ui->label_3->setText(tr("New user PIN:"));
-    ui->label_4->setText(tr("New user PIN:"));
+    ui->label_3->setText(tr("New User PIN:"));
+    ui->label_4->setText(tr("New User PIN:"));
     break;
   case STICK20_PASSWORD_KIND_UPDATE:
     this->setWindowTitle(tr("Change Firmware Password"));
-    ui->label_2->setText(tr("Firmware Password:"));
+    ui->label_2->setText(tr("Current Firmware Password:"));
     ui->label_3->setText(tr("New Firmware Password:"));
-    ui->label_4->setText(tr("New Firmware Password (confirm):"));
+    ui->label_4->setText(tr("New Firmware Password:"));
     break;
   }
 }

--- a/src/ui/stick20changepassworddialog.cpp
+++ b/src/ui/stick20changepassworddialog.cpp
@@ -103,6 +103,9 @@ void DialogChangePassword::UpdatePasswordRetry() {
   }
   if (retryCount == 0) {
     csApplet->warningBox(noTrialsLeft);
+    QString cssRed = "QLabel {color: red; font-weight: bold}";
+    ui->retryCount->setStyleSheet(cssRed);
+    ui->retryCountLabel->setStyleSheet(cssRed);
   }
   ui->retryCount->setText(QString::number(retryCount));
   ui->retryCount->repaint();

--- a/src/ui/stick20changepassworddialog.cpp
+++ b/src/ui/stick20changepassworddialog.cpp
@@ -270,7 +270,7 @@ void DialogChangePassword::Stick10ChangePassword(void) {
 
 // FIXME code doubles SendNewPassword
 bool DialogChangePassword::ResetUserPassword(void) {
-  bool communicationSuccess;
+  bool communicationAndCommandSuccess;
   QByteArray PasswordString;
   unsigned char Data[STICK20_PASSOWRD_LEN + 2];
 
@@ -281,8 +281,8 @@ bool DialogChangePassword::ResetUserPassword(void) {
   STRNCPY((char *)&Data[1], STICK20_PASSOWRD_LEN - 1, PasswordString.data(), STICK20_PASSOWRD_LEN);
   Data[STICK20_PASSOWRD_LEN + 1] = 0;
 
-  communicationSuccess = cryptostick->stick20SendPassword(Data);
-  if (!communicationSuccess) {
+  communicationAndCommandSuccess = cryptostick->stick20SendPassword(Data);
+  if (!communicationAndCommandSuccess) {
     csApplet->warningBox(tr("There was a problem during communicating with device. Please retry."));
     return false;
   }
@@ -297,17 +297,13 @@ bool DialogChangePassword::ResetUserPassword(void) {
   PasswordString = ui->lineEdit_NewPW_1->text().toLatin1();
   STRNCPY((char *)&Data[1], STICK20_PASSOWRD_LEN - 1, PasswordString.data(), STICK20_PASSOWRD_LEN);
   Data[STICK20_PASSOWRD_LEN + 1] = 0;
-  communicationSuccess = cryptostick->unlockUserPassword(Data) == 0;
-  if (!communicationSuccess) {
-    csApplet->warningBox(tr("There was a problem during communicating with device. Please retry."));
+  communicationAndCommandSuccess = cryptostick->unlockUserPassword(Data) == 0;
+  if (!communicationAndCommandSuccess) {
+    csApplet->warningBox(tr("There was a problem during communicating with device or new password "
+                            "is not correct. Please retry."));
     return false;
   }
 
-  bool isNewUserPasswordCorrect = CheckResponse(FALSE) == 1;
-  if (!isNewUserPasswordCorrect) {
-    csApplet->warningBox(tr("New password is not correct. Please retry."));
-    return false;
-  }
   csApplet->messageBox(tr("New User password is set"));
   return true;
 }

--- a/src/ui/stick20changepassworddialog.cpp
+++ b/src/ui/stick20changepassworddialog.cpp
@@ -67,29 +67,7 @@ DialogChangePassword::DialogChangePassword(QWidget *parent)
   PasswordKind = 0;
 }
 
-/*******************************************************************************
-
-  DialogChangePassword
-
-  Destructor DialogChangePassword
-
-  Reviews
-  Date      Reviewer        Info
-  13.08.13  RB              First review
-
-*******************************************************************************/
-
 DialogChangePassword::~DialogChangePassword() { delete ui; }
-
-/*******************************************************************************
-
-  InitData
-
-  Reviews
-  Date      Reviewer        Info
-  13.08.13  RB              First review
-
-*******************************************************************************/
 
 void DialogChangePassword::InitData(void) {
   // center the password window
@@ -98,8 +76,9 @@ void DialogChangePassword::InitData(void) {
       QStyle::alignedRect(Qt::LeftToRight, Qt::AlignCenter, size(), desktop->availableGeometry()));
   // replace %1 and %2 from text with proper values
   //(min and max of password length)
+  int minimumPasswordLengthAdmin = 8;
   QString text = ui->label_additional_information->text();
-  text = text.arg(minimumPasswordLength).arg(STICK20_PASSOWRD_LEN);
+  text = text.arg(minimumPasswordLength).arg(STICK20_PASSOWRD_LEN).arg(minimumPasswordLengthAdmin);
   ui->label_additional_information->setText(text);
   switch (PasswordKind) {
   case STICK20_PASSWORD_KIND_USER:
@@ -131,16 +110,6 @@ void DialogChangePassword::InitData(void) {
     break;
   }
 }
-
-/*******************************************************************************
-
-  CheckResponse
-
-  Reviews
-  Date      Reviewer        Info
-  13.08.13  RB              First review
-
-*******************************************************************************/
 
 int DialogChangePassword::CheckResponse(bool NoStopFlag) {
   Stick20ResponseTask ResponseTask(this, cryptostick, NULL);

--- a/src/ui/stick20changepassworddialog.cpp
+++ b/src/ui/stick20changepassworddialog.cpp
@@ -96,7 +96,7 @@ void DialogChangePassword::UpdatePasswordRetry() {
     break;
   case STICK20_PASSWORD_KIND_UPDATE:
     // FIXME add firmware counter
-    retryCount = 0;
+    retryCount = 99;
     ui->retryCount->hide();
     ui->retryCountLabel->hide();
     break;
@@ -338,16 +338,12 @@ void DialogChangePassword::ResetUserPasswordStick10(void) {
   }
 }
 
-void DialogChangePassword::Stick20ChangeUpdatePassword(void) {
-  int ret;
-
+bool DialogChangePassword::Stick20ChangeUpdatePassword(void) {
+  bool commandSuccess;
   int password_length;
-
   QByteArray PasswordString;
-
   password_length = CS20_MAX_UPDATE_PASSWORD_LEN;
   unsigned char old_pin[password_length + 1];
-
   unsigned char new_pin[password_length + 1];
 
   memset(old_pin, 0, password_length + 1);
@@ -360,10 +356,14 @@ void DialogChangePassword::Stick20ChangeUpdatePassword(void) {
   strncpy((char *)new_pin, PasswordString.data(), password_length);
 
   // Change password
-  ret = cryptostick->stick20NewUpdatePassword((uint8_t *)old_pin, (uint8_t *)new_pin);
+  commandSuccess = cryptostick->stick20NewUpdatePassword((uint8_t *)old_pin, (uint8_t *)new_pin);
 
-  if (!ret)
-    csApplet->warningBox(tr("Wrong password."));
+  if (!commandSuccess) {
+    csApplet->warningBox(
+        tr("Wrong password or there was a communication problem with the device."));
+    return false;
+  }
+  return true;
 }
 
 /*******************************************************************************
@@ -444,8 +444,7 @@ void DialogChangePassword::accept() {
     success = true;
     break;
   case STICK20_PASSWORD_KIND_UPDATE:
-    Stick20ChangeUpdatePassword();
-    success = true;
+    success = Stick20ChangeUpdatePassword();
     break;
   default:
     break;

--- a/src/ui/stick20changepassworddialog.h
+++ b/src/ui/stick20changepassworddialog.h
@@ -48,7 +48,7 @@ private:
   void UpdatePasswordRetry(void);
   bool SendNewPassword(void);
   void Stick10ChangePassword(void);
-  void ResetUserPassword(void);
+  bool ResetUserPassword(void);
   void ResetUserPasswordStick10(void);
   void Stick20ChangeUpdatePassword(void);
   int CheckResponse(bool NoStopFlag);

--- a/src/ui/stick20changepassworddialog.h
+++ b/src/ui/stick20changepassworddialog.h
@@ -50,7 +50,7 @@ private:
   void Stick10ChangePassword(void);
   bool ResetUserPassword(void);
   void ResetUserPasswordStick10(void);
-  void Stick20ChangeUpdatePassword(void);
+  bool Stick20ChangeUpdatePassword(void);
   int CheckResponse(bool NoStopFlag);
   void clearFields();
 };

--- a/src/ui/stick20changepassworddialog.h
+++ b/src/ui/stick20changepassworddialog.h
@@ -45,7 +45,7 @@ private slots:
 private:
   Ui::DialogChangePassword *ui;
   void accept(void);
-  void SendNewPassword(void);
+  bool SendNewPassword(void);
   void Stick10ChangePassword(void);
   void ResetUserPassword(void);
   void ResetUserPasswordStick10(void);

--- a/src/ui/stick20changepassworddialog.h
+++ b/src/ui/stick20changepassworddialog.h
@@ -45,6 +45,7 @@ private slots:
 private:
   Ui::DialogChangePassword *ui;
   void accept(void);
+  void UpdatePasswordRetry(void);
   bool SendNewPassword(void);
   void Stick10ChangePassword(void);
   void ResetUserPassword(void);

--- a/ui/stick20changepassworddialog.ui
+++ b/ui/stick20changepassworddialog.ui
@@ -131,6 +131,24 @@
     </widget>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="retryCountLabel">
+       <property name="text">
+        <string>Retry count left:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="retryCount">
+       <property name="text">
+        <string notr="true">3</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/ui/stick20changepassworddialog.ui
+++ b/ui/stick20changepassworddialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>453</width>
-    <height>408</height>
+    <width>420</width>
+    <height>369</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -16,6 +16,12 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>420</width>
+    <height>300</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string>Change user PIN</string>
   </property>
@@ -23,7 +29,7 @@
    <iconset resource="../resources.qrc">
     <normaloff>:/images/CS_icon.png</normaloff>:/images/CS_icon.png</iconset>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_5">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QFrame" name="frame">
      <property name="sizePolicy">
@@ -111,55 +117,58 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QLabel" name="label_additional_information">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="mouseTracking">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;PINs can only be tried three times and are secure against brute force guessing. A PIN of 6 or 8 digits is sufficiently long and longer or more complex PINs are usually unnecessary. The minimum length is %1 (%3 for admin) and the maximum length is %2 chars. &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="scaledContents">
+         <bool>false</bool>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="retryCountLabel">
+          <property name="text">
+           <string>Retry count left:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="retryCount">
+          <property name="text">
+           <string notr="true">3</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="label_additional_information">
-     <property name="mouseTracking">
-      <bool>true</bool>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;PINs can only be tried three times and are secure against brute force guessing. A PIN of 6 or 8 digits is sufficiently long and longer or more complex PINs are usually unnecessary. The minimum length is %1 (%3 for admin) and the maximum length is %2 chars. &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="scaledContents">
-      <bool>false</bool>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="retryCountLabel">
-       <property name="text">
-        <string>Retry count left:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="retryCount">
-       <property name="text">
-        <string notr="true">3</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Expanding</enum>
-     </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>0</width>
-       <height>0</height>
+       <width>20</width>
+       <height>40</height>
       </size>
      </property>
     </spacer>

--- a/ui/stick20changepassworddialog.ui
+++ b/ui/stick20changepassworddialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>453</width>
-    <height>339</height>
+    <height>408</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -120,7 +120,7 @@
       <bool>true</bool>
      </property>
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;PINs can only be tried three times and are secure against brute force guessing. A PIN of 6 or 8 digits is sufficiently long and longer or more complex PINs are usually unnecessary. The minimum length is %1 and the maximum length is %2 chars.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;PINs can only be tried three times and are secure against brute force guessing. A PIN of 6 or 8 digits is sufficiently long and longer or more complex PINs are usually unnecessary. The minimum length is %1 (%3 for admin) and the maximum length is %2 chars. &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="scaledContents">
       <bool>false</bool>

--- a/ui/stick20updatedialog.ui
+++ b/ui/stick20updatedialog.ui
@@ -67,6 +67,9 @@
         <property name="wordWrap">
          <bool>true</bool>
         </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
       <item>


### PR DESCRIPTION
This is a fix for issue #38 

Fixed feedback for changing firmware, user and admin passwords for NK Storage.
Left to do:
- feedback for resetting user password
- feedback for setting update password

Tested on Ubuntu 16.04 with NK Storage.