### PR TITLE
Issue 97 firmware password feedback no debug

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -2392,11 +2392,13 @@ bool Device::stick20NewUpdatePassword(uint8_t *old_password, uint8_t *new_passwo
 
   cmd = new Command(STICK20_CMD_CHANGE_UPDATE_PIN, SendString, 33);
   res = sendCommand(cmd);
+  bool sentWithSuccess = res > 0;
   delete cmd;
 
   Stick20ResponseTask ResponseTask(NULL, this, NULL);
   ResponseTask.NoStopWhenStatusOK();
   ResponseTask.GetResponse();
+  bool commandSuccess = ResponseTask.ResultValue == TRUE;
 
 /*
   Sleep::msleep(2000);
@@ -2405,7 +2407,7 @@ bool Device::stick20NewUpdatePassword(uint8_t *old_password, uint8_t *new_passwo
   delete resp;
 */
 
-  return res > 0;
+  return sentWithSuccess && commandSuccess;
 }
 
 /*******************************************************************************

--- a/src/ui/stick20changepassworddialog.cpp
+++ b/src/ui/stick20changepassworddialog.cpp
@@ -363,6 +363,8 @@ bool DialogChangePassword::Stick20ChangeUpdatePassword(void) {
         tr("Wrong password or there was a communication problem with the device."));
     return false;
   }
+  csApplet->warningBox(
+      tr("Password has been changed with success!"));
   return true;
 }
 


### PR DESCRIPTION
Fix for issue #97 
Code enables proper feedback receiving from device
Tested on Ubuntu 16.04 and Windows 8.
There are some issues however with sub-sequential password changing, possibly caused by firmware (https://github.com/Nitrokey/nitrokey-storage-firmware/issues/11).