### PR TITLE
Hidden setup usability fix

### DIFF
--- a/i18n/nitrokey_de_DE.ts
+++ b/i18n/nitrokey_de_DE.ts
@@ -790,24 +790,12 @@ Bitte versuchen Sie es erneut</translation>
         <translation>Nitrokey Storage wurde verbunden</translation>
     </message>
     <message>
-        <source>Tests</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Number of tests:</source>
         <translation type="vanished">Anzahl der Tests:</translation>
     </message>
     <message>
         <source>HOTP counter:</source>
         <translation type="vanished">HOTP-Zähler:</translation>
-    </message>
-    <message>
-        <source>Test HOTP</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Test TOTP</source>
-        <translation></translation>
     </message>
     <message>
         <source>Password Safe</source>
@@ -1964,66 +1952,6 @@ Die Aktualisierung der Firmware ist daher nicht möglich.</translation>
     <message>
         <source>Wrong size of hidden volume</source>
         <translation>Falsche Größe des Versteckten Volumens</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;You should understand the properties of hidden volumes before proceeding. It can destroy your encrypted data! &lt;br/&gt;Please read &lt;/span&gt;&lt;a href=&quot;https://www.nitrokey.com/documentation/hidden-volumes&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline; color:#0000ff;&quot;&gt;these instructions&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-weight:600;&quot;&gt; first.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;1. You may want to copy some innocuous files to the encrypted data.&lt;br/&gt;2. Configure hidden volumes in this dialogue. &lt;br/&gt;3. Once you configured a hidden volume you must not use/write to the encryption volume anymore. Otherwise it may destroy the data in your hidden volume.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Password settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Password strength:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>length</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>lower case</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>upper case</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>numbers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hidden Volume settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>MB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>GB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Size will be rounded down to integral percent of total storage size (%1MB)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hidden volume not positioned in unwritten space. Please set your volume between %1% and %2% of total SD card size.</source>

--- a/i18n/nitrokey_de_DE.ts
+++ b/i18n/nitrokey_de_DE.ts
@@ -790,12 +790,24 @@ Bitte versuchen Sie es erneut</translation>
         <translation>Nitrokey Storage wurde verbunden</translation>
     </message>
     <message>
+        <source>Tests</source>
+        <translation></translation>
+    </message>
+    <message>
         <source>Number of tests:</source>
         <translation type="vanished">Anzahl der Tests:</translation>
     </message>
     <message>
         <source>HOTP counter:</source>
         <translation type="vanished">HOTP-Zähler:</translation>
+    </message>
+    <message>
+        <source>Test HOTP</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Test TOTP</source>
+        <translation></translation>
     </message>
     <message>
         <source>Password Safe</source>
@@ -1830,6 +1842,46 @@ Die Aktualisierung der Firmware ist daher nicht möglich.</translation>
         <translation>Versteckte Volumen Einrichten</translation>
     </message>
     <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;You should understand the properties of hidden volumes before proceeding. It can destroy your encrypted data! &lt;br/&gt;Please read &lt;/span&gt;&lt;a href=&quot;https://www.nitrokey.com/documentation/hidden-volumes&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline; color:#0000ff;&quot;&gt;these instructions&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-weight:600;&quot;&gt; first.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;1. You may want to copy some innocuous files to the encrypted data.&lt;br/&gt;2. Configure hidden volumes in this dialogue. &lt;br/&gt;3. Once you configured a hidden volume you must not use/write to the encryption volume anymore. Otherwise it may destroy the data in your hidden volume.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password strength:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lower case</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>upper case</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden Volume settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Hidden volume slot 1</source>
         <translation>Verstecktes Volumen 1</translation>
     </message>
@@ -1846,16 +1898,36 @@ Die Aktualisierung der Firmware ist daher nicht möglich.</translation>
         <translation>Verstecktes Volumen 4</translation>
     </message>
     <message>
+        <source>Unit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Size will be rounded down to integral percent of total storage size (%1MB)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>High water mark</source>
-        <translation>Höchster Stand</translation>
+        <translation type="vanished">Höchster Stand</translation>
     </message>
     <message>
         <source>Start at % of SD size:</source>
-        <translation>Start bei % des Speichers:</translation>
+        <translation type="vanished">Start bei % des Speichers:</translation>
     </message>
     <message>
         <source>End at % of SD size:</source>
-        <translation>Ende bei % des Speichers:</translation>
+        <translation type="vanished">Ende bei % des Speichers:</translation>
     </message>
     <message>
         <source>Password:</source>
@@ -1863,7 +1935,7 @@ Die Aktualisierung der Firmware ist daher nicht möglich.</translation>
     </message>
     <message>
         <source>12345678901234567890</source>
-        <translation>12345678901234567890</translation>
+        <translation type="vanished">12345678901234567890</translation>
     </message>
     <message>
         <source>Show password</source>
@@ -1871,15 +1943,15 @@ Die Aktualisierung der Firmware ist daher nicht möglich.</translation>
     </message>
     <message>
         <source>Entropy guess:</source>
-        <translation>Zufälligkeit:</translation>
+        <translation type="vanished">Zufälligkeit:</translation>
     </message>
     <message>
         <source> bits for random chars</source>
-        <translation>Bits bei zufälligen Zeichen</translation>
+        <translation type="vanished">Bits bei zufälligen Zeichen</translation>
     </message>
     <message>
         <source> for real words</source>
-        <translation>bei Verwendung von Wörtern</translation>
+        <translation type="vanished">bei Verwendung von Wörtern</translation>
     </message>
     <message>
         <source>Your password is too short. Use at least 8 characters.</source>
@@ -1892,6 +1964,107 @@ Die Aktualisierung der Firmware ist daher nicht möglich.</translation>
     <message>
         <source>Wrong size of hidden volume</source>
         <translation>Falsche Größe des Versteckten Volumens</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;You should understand the properties of hidden volumes before proceeding. It can destroy your encrypted data! &lt;br/&gt;Please read &lt;/span&gt;&lt;a href=&quot;https://www.nitrokey.com/documentation/hidden-volumes&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline; color:#0000ff;&quot;&gt;these instructions&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-weight:600;&quot;&gt; first.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;1. You may want to copy some innocuous files to the encrypted data.&lt;br/&gt;2. Configure hidden volumes in this dialogue. &lt;br/&gt;3. Once you configured a hidden volume you must not use/write to the encryption volume anymore. Otherwise it may destroy the data in your hidden volume.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password strength:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lower case</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>upper case</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden Volume settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Size will be rounded down to integral percent of total storage size (%1MB)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden volume not positioned in unwritten space. Please set your volume between %1% and %2% of total SD card size.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Very Weak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strong</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Very Strong</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The unwritten area available for hidden volume
+is between %1 % and %2 % of the storage size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Storage capacity: %1GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start hidden volume at %1 of the encrypted storage:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End hidden volume at %1 of the encrypted storage:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/i18n/nitrokey_en.ts
+++ b/i18n/nitrokey_en.ts
@@ -606,6 +606,14 @@ Please retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Protect OTP by user PIN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Forget PIN after 10 minutes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>USB-Keyboard only</source>
         <translation type="unfinished"></translation>
     </message>
@@ -631,6 +639,26 @@ Please retry</source>
     </message>
     <message>
         <source>Send HOTP2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of tests:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HOTP counter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test HOTP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test TOTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1586,6 +1614,46 @@ Firmware update is not possible.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;You should understand the properties of hidden volumes before proceeding. It can destroy your encrypted data! &lt;br/&gt;Please read &lt;/span&gt;&lt;a href=&quot;https://www.nitrokey.com/documentation/hidden-volumes&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline; color:#0000ff;&quot;&gt;these instructions&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-weight:600;&quot;&gt; first.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;1. You may want to copy some innocuous files to the encrypted data.&lt;br/&gt;2. Configure hidden volumes in this dialogue. &lt;br/&gt;3. Once you configured a hidden volume you must not use/write to the encryption volume anymore. Otherwise it may destroy the data in your hidden volume.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password strength:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lower case</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>upper case</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden Volume settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Hidden volume slot 1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1602,40 +1670,12 @@ Firmware update is not possible.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>High water mark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Start at % of SD size:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>End at % of SD size:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Password:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>12345678901234567890</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show password</source>
         <translation>Show password</translation>
-    </message>
-    <message>
-        <source>Entropy guess:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> bits for random chars</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> for real words</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your password is too short. Use at least 8 characters.</source>
@@ -1647,6 +1687,155 @@ Firmware update is not possible.</source>
     </message>
     <message>
         <source>Wrong size of hidden volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;You should understand the properties of hidden volumes before proceeding. It can destroy your encrypted data! &lt;br/&gt;Please read &lt;/span&gt;&lt;a href=&quot;https://www.nitrokey.com/documentation/hidden-volumes&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline; color:#0000ff;&quot;&gt;these instructions&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-weight:600;&quot;&gt; first.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;1. You may want to copy some innocuous files to the encrypted data.&lt;br/&gt;2. Configure hidden volumes in this dialogue. &lt;br/&gt;3. Once you configured a hidden volume you must not use/write to the encryption volume anymore. Otherwise it may destroy the data in your hidden volume.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password strength:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>lower case</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>upper case</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>symbols</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden Volume settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Size will be rounded down to integral percent of total storage size (%1MB)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden volume not positioned in unwritten space. Please set your volume between %1% and %2% of total SD card size.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Very Weak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Size will be rounded down to integral percent of total storage size (%1MB)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show password</source>
+        <translation>Show password</translation>
+    </message>
+    <message>
+        <source>Your password is too short. Use at least 8 characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The passwords are not identical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Wrong size of hidden volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hidden volume not positioned in unwritten space. Please set your volume between %1% and %2% of total SD card size.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Very Weak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Strong</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Very Strong</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The unwritten area available for hidden volume
+is between %1 % and %2 % of the storage size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Storage capacity: %1GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start hidden volume at %1 of the encrypted storage:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End hidden volume at %1 of the encrypted storage:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/i18n/nitrokey_en.ts
+++ b/i18n/nitrokey_en.ts
@@ -606,14 +606,6 @@ Please retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Protect OTP by user PIN</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Forget PIN after 10 minutes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>USB-Keyboard only</source>
         <translation type="unfinished"></translation>
     </message>
@@ -639,26 +631,6 @@ Please retry</source>
     </message>
     <message>
         <source>Send HOTP2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tests</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of tests:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>HOTP counter:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Test HOTP</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Test TOTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1690,46 +1662,6 @@ Firmware update is not possible.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;You should understand the properties of hidden volumes before proceeding. It can destroy your encrypted data! &lt;br/&gt;Please read &lt;/span&gt;&lt;a href=&quot;https://www.nitrokey.com/documentation/hidden-volumes&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline; color:#0000ff;&quot;&gt;these instructions&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-weight:600;&quot;&gt; first.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;1. You may want to copy some innocuous files to the encrypted data.&lt;br/&gt;2. Configure hidden volumes in this dialogue. &lt;br/&gt;3. Once you configured a hidden volume you must not use/write to the encryption volume anymore. Otherwise it may destroy the data in your hidden volume.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Password settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Password strength:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>length</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>lower case</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>upper case</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>numbers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>symbols</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hidden Volume settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1747,54 +1679,6 @@ Firmware update is not possible.</source>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Size will be rounded down to integral percent of total storage size (%1MB)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hidden volume not positioned in unwritten space. Please set your volume between %1% and %2% of total SD card size.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Very Weak</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>MB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>GB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Size will be rounded down to integral percent of total storage size (%1MB)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Password:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show password</source>
-        <translation>Show password</translation>
-    </message>
-    <message>
-        <source>Your password is too short. Use at least 8 characters.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>The passwords are not identical</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wrong size of hidden volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2696,6 +2696,9 @@ void MainWindow::startStick20SetupHiddenVolume() {
     ret = 0; // Do something ?
   }
 
+
+  //get SD card size
+  ret = cryptostick->stick20ProductionTest();
   HVDialog.setHighWaterMarkText();
 
   ret = HVDialog.exec();

--- a/src/ui/stick20hiddenvolumedialog.cpp
+++ b/src/ui/stick20hiddenvolumedialog.cpp
@@ -125,13 +125,13 @@ void stick20HiddenVolumeDialog::on_buttonBox_clicked(QAbstractButton *button) {
 
 struct charset_space {
   int CharSpace;
-  int HasLowerAlpha :1;
-  int HasUpperAlpha :1;
-  int HasGermanChars :1;
-  int HasNumber :1;
-  int HasSpecialChars1 :1;
-  int HasSpecialChars2 :1;
-  int HasSpecialChars3 :1;
+  int HasLowerAlpha : 1;
+  int HasUpperAlpha : 1;
+  int HasGermanChars : 1;
+  int HasNumber : 1;
+  int HasSpecialChars1 : 1;
+  int HasSpecialChars2 : 1;
+  int HasSpecialChars3 : 1;
   void clear() { memset(this, 0, sizeof(*this)); }
 } c;
 
@@ -208,8 +208,8 @@ void stick20HiddenVolumeDialog::on_HVPasswordEdit_textChanged(const QString &arg
     Entropy = 0;
   }
   // == using human readable symbols, 127 bits
-//  ui->HVEntropieRealWords->setText(
-//      QString("%1").sprintf("using human readable symbols: %3.1lf", Entropy / 2.0));
+  //  ui->HVEntropieRealWords->setText(
+  //      QString("%1").sprintf("using human readable symbols: %3.1lf", Entropy / 2.0));
   int strength = password_human_strength(Entropy);
   ui->password_strength_progressBar->setFormat(labels[strength]);
   ui->password_strength_progressBar->setValue(100.0 * Entropy / 64.0 / 2.0);
@@ -236,9 +236,10 @@ void stick20HiddenVolumeDialog::setHighWaterMarkText(void) {
   }
 
   ui->HVSdCardHighWaterMark->setText(
-      QString("%1").sprintf("The unwritten area available for hidden volume\nis between "
-                            "%d %% and %d %% of the sd card size",
-                            HighWatermarkMin, HighWatermarkMax));
+      tr("The unwritten area available for hidden volume\nis between "
+         "%1 % and %2 % of the storage size")
+          .arg(HighWatermarkMin)
+          .arg(HighWatermarkMax));
 
   // Set valid input range
   //  ui->StartBlockSpin->setMaximum(HighWatermarkMax - 1);

--- a/src/ui/stick20hiddenvolumedialog.cpp
+++ b/src/ui/stick20hiddenvolumedialog.cpp
@@ -99,6 +99,11 @@ void stick20HiddenVolumeDialog::on_buttonBox_clicked(QAbstractButton *button) {
       return;
     }
 
+    if (HV_Setup_st.StartBlockPercent_u8 <  HighWatermarkMin || HV_Setup_st.EndBlockPercent_u8 > HighWatermarkMax){
+        csApplet()->warningBox(tr("Hidden volume not positioned in unwritten space"));
+        return;
+    }
+
     STRNCPY((char *)HV_Setup_st.HiddenVolumePassword_au8,
             sizeof(HV_Setup_st.HiddenVolumePassword_au8), ui->HVPasswordEdit->text().toLatin1(),
             MAX_HIDDEN_VOLUME_PASSOWORD_SIZE);
@@ -211,10 +216,6 @@ void stick20HiddenVolumeDialog::on_HVPasswordEdit_textChanged(const QString &arg
 }
 
 void stick20HiddenVolumeDialog::setHighWaterMarkText(void) {
-  uint8_t HighWatermarkMin;
-
-  uint8_t HighWatermarkMax;
-
   HighWatermarkMin = SdCardHighWatermark_Write_Min;
   HighWatermarkMax = SdCardHighWatermark_Write_Max;
 
@@ -228,7 +229,7 @@ void stick20HiddenVolumeDialog::setHighWaterMarkText(void) {
   }
 
   ui->HVSdCardHighWaterMark->setText(
-      QString("%1").sprintf("The the unwritten area after plugin is\nbetween "
+      QString("%1").sprintf("The unwritten area after plugin is\nbetween "
                             "%d %% and %d %% of the sd card size",
                             HighWatermarkMin, HighWatermarkMax));
 

--- a/src/ui/stick20hiddenvolumedialog.cpp
+++ b/src/ui/stick20hiddenvolumedialog.cpp
@@ -199,7 +199,7 @@ int password_human_strength(double entropy) {
 void stick20HiddenVolumeDialog::on_HVPasswordEdit_textChanged(const QString &arg1) {
   int Len;
   double Entropy;
-  QString labels[] = {"Very Weak", "Weak", "Medium", "Strong", "Very Strong"};
+  QString labels[] = {tr("Very Weak"), tr("Weak"), tr("Medium"), tr("Strong"), tr("Very Strong")};
 
   Len = arg1.length();
   Entropy = GetEntropy((unsigned char *)arg1.toLatin1().data(), Len);
@@ -208,8 +208,8 @@ void stick20HiddenVolumeDialog::on_HVPasswordEdit_textChanged(const QString &arg
     Entropy = 0;
   }
   // == using human readable symbols, 127 bits
-  ui->HVEntropieRealWords->setText(
-      QString("%1").sprintf("using human readable symbols: %3.1lf", Entropy / 2.0));
+//  ui->HVEntropieRealWords->setText(
+//      QString("%1").sprintf("using human readable symbols: %3.1lf", Entropy / 2.0));
   int strength = password_human_strength(Entropy);
   ui->password_strength_progressBar->setFormat(labels[strength]);
   ui->password_strength_progressBar->setValue(100.0 * Entropy / 64.0 / 2.0);
@@ -249,7 +249,7 @@ void stick20HiddenVolumeDialog::setHighWaterMarkText(void) {
   //  ui->EndBlockSpin->setMinimum(HighWatermarkMin + 1);
   ui->EndBlockSpin->setValue(HV_Setup_st.EndBlockPercent_u8);
   int sd_size_GB = Stick20ProductionInfos_st.SD_Card_Size_u8;
-  ui->l_sd_size->setText(QString("SD size: %1GB").arg(sd_size_GB));
+  ui->l_sd_size->setText(tr("Storage capacity: %1GB").arg(sd_size_GB));
   ui->l_rounding_info->setText(ui->l_rounding_info->text().arg((sd_size_GB * 1024 / 100)));
 }
 
@@ -268,8 +268,8 @@ void stick20HiddenVolumeDialog::on_rd_unit_clicked(QString text) {
     i_end_MB = sd_size_MB * current_block_end / 100.0;
   }
 
-  QString start = "Start at %1 of SD size:";
-  QString end = "End at %1 of SD size:";
+  QString start = tr("Start hidden volume at %1 of the encrypted storage:");
+  QString end = tr("End hidden volume at %1 of the encrypted storage:");
   ui->l_sd_start->setText(start.arg(text));
   ui->l_sd_end->setText(end.arg(text));
 

--- a/src/ui/stick20hiddenvolumedialog.cpp
+++ b/src/ui/stick20hiddenvolumedialog.cpp
@@ -111,9 +111,9 @@ void stick20HiddenVolumeDialog::on_buttonBox_clicked(QAbstractButton *button) {
   }
 }
 
-// Based from
+// Based on
 // http://www.emoticode.net/c/optimized-f-the-shannf-the-shannon-entropy-algorithm.html
-// */
+// (site not working as of 2016.08)
 
 struct charset_space{
     int HasLowerAlpha;
@@ -196,9 +196,9 @@ void stick20HiddenVolumeDialog::on_HVPasswordEdit_textChanged(const QString &arg
   if (Entropy < 0) {
       Entropy = 0;
   }
-                // == alphanumeric chars, 127 bits
+                // == using human readable symbols, 127 bits
     ui->HVEntropieRealWords->setText(
-        QString("%1").sprintf(" %3.1lf for real words", Entropy / 2.0));
+        QString("%1").sprintf("using human readable symbols: %3.1lf", Entropy / 2.0));
     int strength = password_human_strength(Entropy);
     ui->password_strength_progressBar->setFormat(labels[strength]);
     ui->password_strength_progressBar->setValue(100.0*Entropy/64.0/2.0);

--- a/src/ui/stick20hiddenvolumedialog.cpp
+++ b/src/ui/stick20hiddenvolumedialog.cpp
@@ -77,6 +77,9 @@ void stick20HiddenVolumeDialog::on_ShowPasswordCheckBox_toggled(bool checked) {
 
 void stick20HiddenVolumeDialog::on_buttonBox_clicked(QAbstractButton *button) {
   if (button == ui->buttonBox->button(QDialogButtonBox::Ok)) {
+      on_rd_percent_clicked();
+      ui->rd_percent->setChecked(true);
+
     if (8 > strlen(ui->HVPasswordEdit->text().toLatin1().data())) {
         csApplet()->warningBox(tr("Your password is too short. Use at least 8 characters."));
       return;

--- a/src/ui/stick20hiddenvolumedialog.cpp
+++ b/src/ui/stick20hiddenvolumedialog.cpp
@@ -40,12 +40,12 @@ stick20HiddenVolumeDialog::stick20HiddenVolumeDialog(QWidget *parent)
 
   ui->comboBox->setCurrentIndex(HV_Setup_st.SlotNr_u8);
 
-//  ui->StartBlockSpin->setMaximum(89);
-//  ui->StartBlockSpin->setMinimum(10);
+  //  ui->StartBlockSpin->setMaximum(89);
+  //  ui->StartBlockSpin->setMinimum(10);
   ui->StartBlockSpin->setValue(HV_Setup_st.StartBlockPercent_u8);
 
-//  ui->EndBlockSpin->setMaximum(90);
-//  ui->EndBlockSpin->setMinimum(11);
+  //  ui->EndBlockSpin->setMaximum(90);
+  //  ui->EndBlockSpin->setMinimum(11);
   ui->EndBlockSpin->setValue(HV_Setup_st.EndBlockPercent_u8);
 
   ui->HVPasswordEdit->setMaxLength(MAX_HIDDEN_VOLUME_PASSOWORD_SIZE);
@@ -60,7 +60,6 @@ stick20HiddenVolumeDialog::stick20HiddenVolumeDialog(QWidget *parent)
 
   on_rd_percent_clicked();
   ui->rd_percent->setChecked(true);
-
 }
 
 stick20HiddenVolumeDialog::~stick20HiddenVolumeDialog() { delete ui; }
@@ -77,8 +76,8 @@ void stick20HiddenVolumeDialog::on_ShowPasswordCheckBox_toggled(bool checked) {
 
 void stick20HiddenVolumeDialog::on_buttonBox_clicked(QAbstractButton *button) {
   if (button == ui->buttonBox->button(QDialogButtonBox::Ok)) {
-      on_rd_percent_clicked();
-      ui->rd_percent->setChecked(true);
+    on_rd_percent_clicked();
+    ui->rd_percent->setChecked(true);
 
     if (8 > strlen(ui->HVPasswordEdit->text().toLatin1().data())) {
         csApplet()->warningBox(tr("Your password is too short. Use at least 8 characters."));
@@ -99,9 +98,13 @@ void stick20HiddenVolumeDialog::on_buttonBox_clicked(QAbstractButton *button) {
       return;
     }
 
-    if (HV_Setup_st.StartBlockPercent_u8 <  HighWatermarkMin || HV_Setup_st.EndBlockPercent_u8 > HighWatermarkMax){
-        csApplet()->warningBox(tr("Hidden volume not positioned in unwritten space. Please set your volume between %1% and %2% of total SD card size.").arg(HighWatermarkMin).arg(HighWatermarkMax));
-        return;
+    if (HV_Setup_st.StartBlockPercent_u8 < HighWatermarkMin ||
+        HV_Setup_st.EndBlockPercent_u8 > HighWatermarkMax) {
+      csApplet()->warningBox(tr("Hidden volume not positioned in unwritten space. Please set your "
+                              "volume between %1% and %2% of total SD card size.")
+                               .arg(HighWatermarkMin)
+                               .arg(HighWatermarkMax));
+      return;
     }
 
     STRNCPY((char *)HV_Setup_st.HiddenVolumePassword_au8,
@@ -120,18 +123,16 @@ void stick20HiddenVolumeDialog::on_buttonBox_clicked(QAbstractButton *button) {
 // http://www.emoticode.net/c/optimized-f-the-shannf-the-shannon-entropy-algorithm.html
 // (site not working as of 2016.08)
 
-struct charset_space{
-    int HasLowerAlpha;
-    int HasUpperAlpha;
-    int HasGermanChars;
-    int HasNumber;
-    int HasSpecialChars1;
-    int HasSpecialChars2;
-    int HasSpecialChars3;
-    int CharSpace;
-    void clear(){
-        memset(this, 0, sizeof(*this));
-    }
+struct charset_space {
+  int HasLowerAlpha;
+  int HasUpperAlpha;
+  int HasGermanChars;
+  int HasNumber;
+  int HasSpecialChars1;
+  int HasSpecialChars2;
+  int HasSpecialChars3;
+  int CharSpace;
+  void clear() { memset(this, 0, sizeof(*this)); }
 } c;
 
 int stick20HiddenVolumeDialog::GetCharsetSpace(unsigned char *Password, size_t size) {
@@ -176,43 +177,49 @@ double stick20HiddenVolumeDialog::GetEntropy(unsigned char *Password, size_t siz
   int CharsetSpace;
 
   CharsetSpace = GetCharsetSpace(Password, size);
-  if (CharsetSpace == 0 ) return 0;
+  if (CharsetSpace == 0)
+    return 0;
   // Entropy by CharsetSpace * size
   Entropy = (double)size * (log((double)CharsetSpace) / log(2.0));
   return (Entropy);
 }
 
-int password_human_strength(double entropy){
-    if (entropy<28) return 0;
-    if (entropy<36) return 1;
-    if (entropy<60) return 2;
-    if (entropy<128) return 3;
-    return 4;
+int password_human_strength(double entropy) {
+  if (entropy < 28)
+    return 0;
+  if (entropy < 36)
+    return 1;
+  if (entropy < 60)
+    return 2;
+  if (entropy < 128)
+    return 3;
+  return 4;
 }
 
 void stick20HiddenVolumeDialog::on_HVPasswordEdit_textChanged(const QString &arg1) {
   int Len;
   double Entropy;
-  QString labels[] = { "Very Weak", "Weak", "Medium", "Strong", "Very Strong" };
+  QString labels[] = {"Very Weak", "Weak", "Medium", "Strong", "Very Strong"};
 
   Len = arg1.length();
   Entropy = GetEntropy((unsigned char *)arg1.toLatin1().data(), Len);
 
   if (Entropy < 0) {
-      Entropy = 0;
+    Entropy = 0;
   }
-                // == using human readable symbols, 127 bits
-    ui->HVEntropieRealWords->setText(
-        QString("%1").sprintf("using human readable symbols: %3.1lf", Entropy / 2.0));
-    int strength = password_human_strength(Entropy);
-    ui->password_strength_progressBar->setFormat(labels[strength]);
-    ui->password_strength_progressBar->setValue(100.0*Entropy/64.0/2.0);
-//    ui->password_strength_progressBar->setValue(100*strength/4);
-   ui->cb_lower_case->setChecked(c.HasLowerAlpha);
-   ui->cb_upper_case->setChecked(c.HasUpperAlpha);
-   ui->cb_numbers->setChecked(c.HasNumber);
-   ui->cb_symbols->setChecked(c.HasSpecialChars1 || c.HasSpecialChars2 || c.HasSpecialChars3 || c.HasGermanChars);
-    ui->cb_length->setChecked(Len>12);
+  // == using human readable symbols, 127 bits
+  ui->HVEntropieRealWords->setText(
+      QString("%1").sprintf("using human readable symbols: %3.1lf", Entropy / 2.0));
+  int strength = password_human_strength(Entropy);
+  ui->password_strength_progressBar->setFormat(labels[strength]);
+  ui->password_strength_progressBar->setValue(100.0 * Entropy / 64.0 / 2.0);
+  //    ui->password_strength_progressBar->setValue(100*strength/4);
+  ui->cb_lower_case->setChecked(c.HasLowerAlpha);
+  ui->cb_upper_case->setChecked(c.HasUpperAlpha);
+  ui->cb_numbers->setChecked(c.HasNumber);
+  ui->cb_symbols->setChecked(c.HasSpecialChars1 || c.HasSpecialChars2 || c.HasSpecialChars3 ||
+                             c.HasGermanChars);
+  ui->cb_length->setChecked(Len > 12);
 }
 
 void stick20HiddenVolumeDialog::setHighWaterMarkText(void) {
@@ -234,93 +241,79 @@ void stick20HiddenVolumeDialog::setHighWaterMarkText(void) {
                             HighWatermarkMin, HighWatermarkMax));
 
   // Set valid input range
-//  ui->StartBlockSpin->setMaximum(HighWatermarkMax - 1);
-//  ui->StartBlockSpin->setMinimum(HighWatermarkMin);
+  //  ui->StartBlockSpin->setMaximum(HighWatermarkMax - 1);
+  //  ui->StartBlockSpin->setMinimum(HighWatermarkMin);
   ui->StartBlockSpin->setValue(HV_Setup_st.StartBlockPercent_u8);
 
-//  ui->EndBlockSpin->setMaximum(HighWatermarkMax);
-//  ui->EndBlockSpin->setMinimum(HighWatermarkMin + 1);
+  //  ui->EndBlockSpin->setMaximum(HighWatermarkMax);
+  //  ui->EndBlockSpin->setMinimum(HighWatermarkMin + 1);
   ui->EndBlockSpin->setValue(HV_Setup_st.EndBlockPercent_u8);
   int sd_size_GB = Stick20ProductionInfos_st.SD_Card_Size_u8;
-  ui->l_sd_size->setText(QString("SD size: %1GB").arg(sd_size_GB)) ;
-  ui->l_rounding_info->setText( ui->l_rounding_info->text().arg((sd_size_GB*1024/100)) );
+  ui->l_sd_size->setText(QString("SD size: %1GB").arg(sd_size_GB));
+  ui->l_rounding_info->setText(ui->l_rounding_info->text().arg((sd_size_GB * 1024 / 100)));
 }
 
 static char last = '%';
 static double i_start_MB = 0;
 static double i_end_MB = 0;
 
+void stick20HiddenVolumeDialog::on_rd_unit_clicked(QString text) {
+  size_t sd_size_MB = Stick20ProductionInfos_st.SD_Card_Size_u8 * 1024;
 
-void stick20HiddenVolumeDialog::on_rd_unit_clicked(QString text)
-{
- size_t sd_size_MB = Stick20ProductionInfos_st.SD_Card_Size_u8*1024;
+  double current_block_start = ui->StartBlockSpin->value();
+  double current_block_end = ui->EndBlockSpin->value();
 
- double current_block_start = ui->StartBlockSpin->value();
- double current_block_end = ui->EndBlockSpin->value();
+  if (i_start_MB == 0) {
+    i_start_MB = sd_size_MB * current_block_start / 100.0;
+    i_end_MB = sd_size_MB * current_block_end / 100.0;
+  }
 
+  QString start = "Start at %1 of SD size:";
+  QString end = "End at %1 of SD size:";
+  ui->l_sd_start->setText(start.arg(text));
+  ui->l_sd_end->setText(end.arg(text));
 
- if (i_start_MB == 0 ){
-     i_start_MB = sd_size_MB * current_block_start /100.0;
-     i_end_MB = sd_size_MB *  current_block_end /100.0;
- }
+  switch (last) {
+  case 'M':
+    i_start_MB = current_block_start;
+    i_end_MB = current_block_end;
+    break;
+  case 'G':
+    i_start_MB = current_block_start * 1024;
+    i_end_MB = current_block_end * 1024;
+    break;
+  case '%':
+    i_start_MB = current_block_start * sd_size_MB / 100.0;
+    i_end_MB = current_block_end * sd_size_MB / 100.0;
+    break;
+  default:
+    break;
+  }
 
- QString start = "Start at %1 of SD size:";
- QString end = "End at %1 of SD size:";
- ui->l_sd_start->setText( start.arg( text )  );
- ui->l_sd_end->setText( end.arg( text )  );
+  char current = (int)text.data()[0].toLatin1();
 
+  switch (current) {
+  case 'M':
+    ui->StartBlockSpin->setValue(i_start_MB);
+    ui->EndBlockSpin->setValue(i_end_MB);
+    break;
+  case 'G':
+    ui->StartBlockSpin->setValue(i_start_MB / 1024.0);
+    ui->EndBlockSpin->setValue(i_end_MB / 1024.0);
+    break;
+  case '%':
+    ui->StartBlockSpin->setValue(100.0 * i_start_MB / sd_size_MB);
+    ui->EndBlockSpin->setValue(100.0 * i_end_MB / sd_size_MB);
+    break;
+  default:
+    break;
+  }
 
- switch (last){
- case 'M':
-     i_start_MB = current_block_start;
-     i_end_MB = current_block_end;
-     break;
- case 'G':
-     i_start_MB = current_block_start*1024;
-     i_end_MB = current_block_end*1024;
-     break;
- case '%':
-     i_start_MB = current_block_start*sd_size_MB/100.0;
-     i_end_MB = current_block_end*sd_size_MB/100.0;
-     break;
- default:
-     break;
-
- }
-
- char current = (int)text.data()[0].toLatin1();
-
- switch( current ){
- case 'M':
-     ui->StartBlockSpin->setValue( i_start_MB );
-     ui->EndBlockSpin->setValue( i_end_MB );
-     break;
- case 'G':
-     ui->StartBlockSpin->setValue( i_start_MB/1024.0 );
-     ui->EndBlockSpin->setValue( i_end_MB/1024.0 );
-     break;
- case '%':
-     ui->StartBlockSpin->setValue( 100.0*i_start_MB/sd_size_MB );
-     ui->EndBlockSpin->setValue( 100.0*i_end_MB/sd_size_MB );
-     break;
- default:
-     break;
- }
-
- last = current;
+  last = current;
 }
 
-void stick20HiddenVolumeDialog::on_rd_MB_clicked()
-{
-    on_rd_unit_clicked("MB");
-}
+void stick20HiddenVolumeDialog::on_rd_MB_clicked() { on_rd_unit_clicked("MB"); }
 
-void stick20HiddenVolumeDialog::on_rd_GB_clicked()
-{
-    on_rd_unit_clicked("GB");
-}
+void stick20HiddenVolumeDialog::on_rd_GB_clicked() { on_rd_unit_clicked("GB"); }
 
-void stick20HiddenVolumeDialog::on_rd_percent_clicked()
-{
-    on_rd_unit_clicked("%");
-}
+void stick20HiddenVolumeDialog::on_rd_percent_clicked() { on_rd_unit_clicked("%"); }

--- a/src/ui/stick20hiddenvolumedialog.cpp
+++ b/src/ui/stick20hiddenvolumedialog.cpp
@@ -124,14 +124,14 @@ void stick20HiddenVolumeDialog::on_buttonBox_clicked(QAbstractButton *button) {
 // (site not working as of 2016.08)
 
 struct charset_space {
-  int HasLowerAlpha;
-  int HasUpperAlpha;
-  int HasGermanChars;
-  int HasNumber;
-  int HasSpecialChars1;
-  int HasSpecialChars2;
-  int HasSpecialChars3;
   int CharSpace;
+  int HasLowerAlpha :1;
+  int HasUpperAlpha :1;
+  int HasGermanChars :1;
+  int HasNumber :1;
+  int HasSpecialChars1 :1;
+  int HasSpecialChars2 :1;
+  int HasSpecialChars3 :1;
   void clear() { memset(this, 0, sizeof(*this)); }
 } c;
 

--- a/src/ui/stick20hiddenvolumedialog.cpp
+++ b/src/ui/stick20hiddenvolumedialog.cpp
@@ -40,12 +40,12 @@ stick20HiddenVolumeDialog::stick20HiddenVolumeDialog(QWidget *parent)
 
   ui->comboBox->setCurrentIndex(HV_Setup_st.SlotNr_u8);
 
-  ui->StartBlockSpin->setMaximum(89);
-  ui->StartBlockSpin->setMinimum(10);
+//  ui->StartBlockSpin->setMaximum(89);
+//  ui->StartBlockSpin->setMinimum(10);
   ui->StartBlockSpin->setValue(HV_Setup_st.StartBlockPercent_u8);
 
-  ui->EndBlockSpin->setMaximum(90);
-  ui->EndBlockSpin->setMinimum(11);
+//  ui->EndBlockSpin->setMaximum(90);
+//  ui->EndBlockSpin->setMinimum(11);
   ui->EndBlockSpin->setValue(HV_Setup_st.EndBlockPercent_u8);
 
   ui->HVPasswordEdit->setMaxLength(MAX_HIDDEN_VOLUME_PASSOWORD_SIZE);
@@ -57,6 +57,10 @@ stick20HiddenVolumeDialog::stick20HiddenVolumeDialog(QWidget *parent)
   ui->HVPasswordEdit->setFocus();
 
   on_HVPasswordEdit_textChanged("");
+
+  on_rd_percent_clicked();
+  ui->rd_percent->setChecked(true);
+
 }
 
 stick20HiddenVolumeDialog::~stick20HiddenVolumeDialog() { delete ui; }
@@ -108,107 +112,99 @@ void stick20HiddenVolumeDialog::on_buttonBox_clicked(QAbstractButton *button) {
 // http://www.emoticode.net/c/optimized-f-the-shannf-the-shannon-entropy-algorithm.html
 // */
 
+struct charset_space{
+    int HasLowerAlpha;
+    int HasUpperAlpha;
+    int HasGermanChars;
+    int HasNumber;
+    int HasSpecialChars1;
+    int HasSpecialChars2;
+    int HasSpecialChars3;
+    int CharSpace;
+    void clear(){
+        memset(this, 0, sizeof(*this));
+    }
+} c;
+
 int stick20HiddenVolumeDialog::GetCharsetSpace(unsigned char *Password, size_t size) {
-  int i;
-
-  int HasLowerAlpha;
-
-  int HasUpperAlpha;
-
-  int HasGermanChars;
-
-  int HasNumber;
-
-  int HasSpecialChars1;
-
-  int HasSpecialChars2;
-
-  int HasSpecialChars3;
-
-  int CharSpace;
-
-  HasLowerAlpha = FALSE;
-  HasUpperAlpha = FALSE;
-  HasGermanChars = FALSE;
-  HasNumber = FALSE;
-  HasSpecialChars1 = FALSE;
-  HasSpecialChars2 = FALSE;
-  HasSpecialChars3 = FALSE;
-  CharSpace = 0;
-
-  for (i = 0; i < (int)size; i++) {
-    if ((FALSE == HasLowerAlpha) && (0 != strchr("abcdefghijklmnopqrstuvwxyz", Password[i]))) {
-      CharSpace += 26;
-      HasLowerAlpha = TRUE;
+  size_t i;
+  c.clear();
+  for (i = 0; i < size; i++) {
+    if ((FALSE == c.HasLowerAlpha) && (0 != strchr("abcdefghijklmnopqrstuvwxyz", Password[i]))) {
+      c.CharSpace += 26;
+      c.HasLowerAlpha = TRUE;
     }
-    if ((FALSE == HasUpperAlpha) && (0 != strchr("ABCDEFGHIJKLMNOPQRSTUVWXYZ", Password[i]))) {
-      CharSpace += 26;
-      HasUpperAlpha = TRUE;
+    if ((FALSE == c.HasUpperAlpha) && (0 != strchr("ABCDEFGHIJKLMNOPQRSTUVWXYZ", Password[i]))) {
+      c.CharSpace += 26;
+      c.HasUpperAlpha = TRUE;
     }
-    if ((FALSE == HasGermanChars) && (0 != strchr("öäüÖÄÜß", Password[i]))) {
-      CharSpace += 7;
-      HasGermanChars = TRUE;
+    if ((FALSE == c.HasGermanChars) && (0 != strchr("öäüÖÄÜß", Password[i]))) {
+      c.CharSpace += 7;
+      c.HasGermanChars = TRUE;
     }
-    if ((FALSE == HasNumber) && (0 != strchr("0123456789", Password[i]))) {
-      CharSpace += 10;
-      HasNumber = TRUE;
+    if ((FALSE == c.HasNumber) && (0 != strchr("0123456789", Password[i]))) {
+      c.CharSpace += 10;
+      c.HasNumber = TRUE;
     }
-    if ((FALSE == HasSpecialChars1) && (0 != strchr("!\"§$%&/()=?'", Password[i]))) {
-      CharSpace += 11;
-      HasSpecialChars1 = TRUE;
+    if ((FALSE == c.HasSpecialChars1) && (0 != strchr("!\"§$%&/()=?'", Password[i]))) {
+      c.CharSpace += 11;
+      c.HasSpecialChars1 = TRUE;
     }
-    if ((FALSE == HasSpecialChars2) && (0 != strchr("',.-#+´;:_*<>^°`", Password[i]))) {
-      CharSpace += 16;
-      HasSpecialChars2 = TRUE;
+    if ((FALSE == c.HasSpecialChars2) && (0 != strchr("',.-#+´;:_*<>^°`", Password[i]))) {
+      c.CharSpace += 16;
+      c.HasSpecialChars2 = TRUE;
     }
-    if ((FALSE == HasSpecialChars3) && (0 != strchr("~[{]}\\|€@", Password[i]))) {
-      CharSpace += 9;
-      HasSpecialChars3 = TRUE;
+    if ((FALSE == c.HasSpecialChars3) && (0 != strchr("~[{]}\\|€@", Password[i]))) {
+      c.CharSpace += 9;
+      c.HasSpecialChars3 = TRUE;
     }
   }
 
-  return (CharSpace);
+  return (c.CharSpace);
 }
 
 double stick20HiddenVolumeDialog::GetEntropy(unsigned char *Password, size_t size) {
   double Entropy = 0.0;
-
   int CharsetSpace;
 
   CharsetSpace = GetCharsetSpace(Password, size);
-
-  Entropy = (double)size * (log((double)CharsetSpace) / log(2.0)); // Entropy
-  // by
-  // CharsetSpace
-  // *
-  // size
-
+  if (CharsetSpace == 0 ) return 0;
+  // Entropy by CharsetSpace * size
+  Entropy = (double)size * (log((double)CharsetSpace) / log(2.0));
   return (Entropy);
+}
+
+int password_human_strength(double entropy){
+    if (entropy<28) return 0;
+    if (entropy<36) return 1;
+    if (entropy<60) return 2;
+    if (entropy<128) return 3;
+    return 4;
 }
 
 void stick20HiddenVolumeDialog::on_HVPasswordEdit_textChanged(const QString &arg1) {
   int Len;
-
   double Entropy;
+  QString labels[] = { "Very Weak", "Weak", "Medium", "Strong", "Very Strong" };
 
   Len = arg1.length();
   Entropy = GetEntropy((unsigned char *)arg1.toLatin1().data(), Len);
 
-  if (0 < Entropy) {
-    // ui->HVEntropieLabel->setText(QString ("%1").sprintf("Entropy
-    // guess: %3.1lf bits for random chars\nEntropy guess: %3.1lf for
-    // real words",Entropy,Entropy/2.0));
+  if (Entropy < 0) {
+      Entropy = 0;
+  }
+                // == alphanumeric chars, 127 bits
     ui->HVEntropieRealWords->setText(
         QString("%1").sprintf(" %3.1lf for real words", Entropy / 2.0));
-    ui->HVEntropieRandChars->setText(
-        QString("%1").sprintf(" %3.1lf bits for random chars", Entropy));
-  } else {
-    // ui->HVEntropieLabel->setText(QString ("%1").sprintf("Entropy
-    // guess: %3.1lf bits for random chars\nEntropy guess: %3.1lf for
-    // real words",0.0,0.0));
-    ui->HVEntropieRealWords->setText(QString("%1").sprintf(" %3.1lf for real words", 0.0));
-    ui->HVEntropieRandChars->setText(QString("%1").sprintf(" %3.1lf bits for random chars", 0.0));
-  }
+    int strength = password_human_strength(Entropy);
+    ui->password_strength_progressBar->setFormat(labels[strength]);
+    ui->password_strength_progressBar->setValue(100.0*Entropy/64.0/2.0);
+//    ui->password_strength_progressBar->setValue(100*strength/4);
+   ui->cb_lower_case->setChecked(c.HasLowerAlpha);
+   ui->cb_upper_case->setChecked(c.HasUpperAlpha);
+   ui->cb_numbers->setChecked(c.HasNumber);
+   ui->cb_symbols->setChecked(c.HasSpecialChars1 || c.HasSpecialChars2 || c.HasSpecialChars3 || c.HasGermanChars);
+    ui->cb_length->setChecked(Len>12);
 }
 
 void stick20HiddenVolumeDialog::setHighWaterMarkText(void) {
@@ -234,11 +230,93 @@ void stick20HiddenVolumeDialog::setHighWaterMarkText(void) {
                             HighWatermarkMin, HighWatermarkMax));
 
   // Set valid input range
-  ui->StartBlockSpin->setMaximum(HighWatermarkMax - 1);
-  ui->StartBlockSpin->setMinimum(HighWatermarkMin);
+//  ui->StartBlockSpin->setMaximum(HighWatermarkMax - 1);
+//  ui->StartBlockSpin->setMinimum(HighWatermarkMin);
   ui->StartBlockSpin->setValue(HV_Setup_st.StartBlockPercent_u8);
 
-  ui->EndBlockSpin->setMaximum(HighWatermarkMax);
-  ui->EndBlockSpin->setMinimum(HighWatermarkMin + 1);
+//  ui->EndBlockSpin->setMaximum(HighWatermarkMax);
+//  ui->EndBlockSpin->setMinimum(HighWatermarkMin + 1);
   ui->EndBlockSpin->setValue(HV_Setup_st.EndBlockPercent_u8);
+  int sd_size_GB = Stick20ProductionInfos_st.SD_Card_Size_u8;
+  ui->l_sd_size->setText(QString("SD size: %1GB").arg(sd_size_GB)) ;
+  ui->l_rounding_info->setText( ui->l_rounding_info->text().arg((sd_size_GB*1024/100)) );
+}
+
+static char last = '%';
+static double i_start_MB = 0;
+static double i_end_MB = 0;
+
+
+void stick20HiddenVolumeDialog::on_rd_unit_clicked(QString text)
+{
+ size_t sd_size_MB = Stick20ProductionInfos_st.SD_Card_Size_u8*1024;
+
+ double current_block_start = ui->StartBlockSpin->value();
+ double current_block_end = ui->EndBlockSpin->value();
+
+
+ if (i_start_MB == 0 ){
+     i_start_MB = sd_size_MB * current_block_start /100.0;
+     i_end_MB = sd_size_MB *  current_block_end /100.0;
+ }
+
+ QString start = "Start at %1 of SD size:";
+ QString end = "End at %1 of SD size:";
+ ui->l_sd_start->setText( start.arg( text )  );
+ ui->l_sd_end->setText( end.arg( text )  );
+
+
+ switch (last){
+ case 'M':
+     i_start_MB = current_block_start;
+     i_end_MB = current_block_end;
+     break;
+ case 'G':
+     i_start_MB = current_block_start*1024;
+     i_end_MB = current_block_end*1024;
+     break;
+ case '%':
+     i_start_MB = current_block_start*sd_size_MB/100.0;
+     i_end_MB = current_block_end*sd_size_MB/100.0;
+     break;
+ default:
+     break;
+
+ }
+
+ char current = (int)text.data()[0].toLatin1();
+
+ switch( current ){
+ case 'M':
+     ui->StartBlockSpin->setValue( i_start_MB );
+     ui->EndBlockSpin->setValue( i_end_MB );
+     break;
+ case 'G':
+     ui->StartBlockSpin->setValue( i_start_MB/1024.0 );
+     ui->EndBlockSpin->setValue( i_end_MB/1024.0 );
+     break;
+ case '%':
+     ui->StartBlockSpin->setValue( 100.0*i_start_MB/sd_size_MB );
+     ui->EndBlockSpin->setValue( 100.0*i_end_MB/sd_size_MB );
+     break;
+ default:
+     break;
+ }
+
+ last = current;
+}
+
+void stick20HiddenVolumeDialog::on_rd_MB_clicked()
+{
+    on_rd_unit_clicked("MB");
+}
+
+void stick20HiddenVolumeDialog::on_rd_GB_clicked()
+{
+    on_rd_unit_clicked("GB");
+}
+
+void stick20HiddenVolumeDialog::on_rd_percent_clicked()
+{
+    on_rd_unit_clicked("%");
 }

--- a/src/ui/stick20hiddenvolumedialog.cpp
+++ b/src/ui/stick20hiddenvolumedialog.cpp
@@ -100,7 +100,7 @@ void stick20HiddenVolumeDialog::on_buttonBox_clicked(QAbstractButton *button) {
     }
 
     if (HV_Setup_st.StartBlockPercent_u8 <  HighWatermarkMin || HV_Setup_st.EndBlockPercent_u8 > HighWatermarkMax){
-        csApplet()->warningBox(tr("Hidden volume not positioned in unwritten space"));
+        csApplet()->warningBox(tr("Hidden volume not positioned in unwritten space. Please set your volume between %1% and %2% of total SD card size.").arg(HighWatermarkMin).arg(HighWatermarkMax));
         return;
     }
 
@@ -229,7 +229,7 @@ void stick20HiddenVolumeDialog::setHighWaterMarkText(void) {
   }
 
   ui->HVSdCardHighWaterMark->setText(
-      QString("%1").sprintf("The unwritten area after plugin is\nbetween "
+      QString("%1").sprintf("The unwritten area available for hidden volume\nis between "
                             "%d %% and %d %% of the sd card size",
                             HighWatermarkMin, HighWatermarkMax));
 

--- a/src/ui/stick20hiddenvolumedialog.h
+++ b/src/ui/stick20hiddenvolumedialog.h
@@ -41,6 +41,9 @@ class stick20HiddenVolumeDialog : public QDialog {
   uint8_t SdCardHighWatermark_Write_Min;
   uint8_t SdCardHighWatermark_Write_Max;
 
+  uint8_t HighWatermarkMin;
+  uint8_t HighWatermarkMax;
+
   void setHighWaterMarkText(void);
   void on_rd_unit_clicked(QString text);
 

--- a/src/ui/stick20hiddenvolumedialog.h
+++ b/src/ui/stick20hiddenvolumedialog.h
@@ -58,7 +58,6 @@ private slots:
   void on_rd_MB_clicked();
   void on_rd_GB_clicked();
 
-
 private:
   Ui::stick20HiddenVolumeDialog *ui;
 };

--- a/src/ui/stick20hiddenvolumedialog.h
+++ b/src/ui/stick20hiddenvolumedialog.h
@@ -42,15 +42,19 @@ class stick20HiddenVolumeDialog : public QDialog {
   uint8_t SdCardHighWatermark_Write_Max;
 
   void setHighWaterMarkText(void);
+  void on_rd_unit_clicked(QString text);
 
 private slots:
   void on_ShowPasswordCheckBox_toggled(bool checked);
 
-  // void on_buttonBox_accepted();
-
   void on_buttonBox_clicked(QAbstractButton *button);
 
   void on_HVPasswordEdit_textChanged(const QString &arg1);
+
+  void on_rd_percent_clicked();
+  void on_rd_MB_clicked();
+  void on_rd_GB_clicked();
+
 
 private:
   Ui::stick20HiddenVolumeDialog *ui;

--- a/ui/stick20hiddenvolumedialog.ui
+++ b/ui/stick20hiddenvolumedialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>349</width>
-    <height>421</height>
+    <width>430</width>
+    <height>452</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -25,7 +25,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>
-    <widget class="QFrame" name="frame">
+    <widget class="QFrame" name="main_frame">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
        <horstretch>0</horstretch>
@@ -43,213 +43,373 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_3">
-        <item>
-         <widget class="QComboBox" name="comboBox">
-          <item>
-           <property name="text">
-            <string>Hidden volume slot 1</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Hidden volume slot 2</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Hidden volume slot 3</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Hidden volume slot 4</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="HVSdCardHighWaterMark">
-          <property name="text">
-           <string>High water mark</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QFormLayout" name="formLayout">
-        <property name="fieldGrowthPolicy">
-         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+       <widget class="QGroupBox" name="password_group">
+        <property name="title">
+         <string>Password settings</string>
         </property>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Start at % of SD size:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <layout class="QFormLayout" name="passwordObjects">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Password:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="HVPasswordEdit">
+           <property name="text">
+            <string notr="true">12345678901234567890</string>
+           </property>
+           <property name="maxLength">
+            <number>20</number>
+           </property>
+           <property name="echoMode">
+            <enum>QLineEdit::Password</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>Password:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="HVPasswordEdit_2">
+           <property name="focusPolicy">
+            <enum>Qt::ClickFocus</enum>
+           </property>
+           <property name="text">
+            <string notr="true">12345678901234567890</string>
+           </property>
+           <property name="maxLength">
+            <number>20</number>
+           </property>
+           <property name="echoMode">
+            <enum>QLineEdit::Password</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QCheckBox" name="ShowPasswordCheckBox">
+           <property name="text">
+            <string>Show password</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0" colspan="2">
+          <layout class="QVBoxLayout" name="entropy_verticalLayout">
+           <item>
+            <widget class="QLabel" name="HVEntropieLabel">
+             <property name="text">
+              <string>Entropy guess:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="HVEntropieRealWords">
+             <property name="text">
+              <string> for real words</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_6">
+             <property name="text">
+              <string>Password strength:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QProgressBar" name="password_strength_progressBar">
+             <property name="value">
+              <number>42</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="chars_kind_layout">
+             <item>
+              <widget class="QCheckBox" name="cb_length">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>length</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="cb_lower_case">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>lower case</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="cb_upper_case">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>upper case</string>
+               </property>
+               <property name="checkable">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="cb_numbers">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>numbers</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="cb_symbols">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>symbols</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="HV_settings_groupBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>101</height>
+         </size>
+        </property>
+        <property name="title">
+         <string>Hidden Volume settings</string>
+        </property>
+        <property name="checkable">
+         <bool>false</bool>
+        </property>
+        <widget class="QFrame" name="verticalFrame">
+         <property name="geometry">
+          <rect>
+           <x>9</x>
+           <y>20</y>
+           <width>381</width>
+           <height>151</height>
+          </rect>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_6">
           <item>
-           <widget class="QSpinBox" name="StartBlockSpin">
+           <widget class="QComboBox" name="comboBox">
+            <item>
+             <property name="text">
+              <string>Hidden volume slot 1</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Hidden volume slot 2</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Hidden volume slot 3</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Hidden volume slot 4</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="HVSdCardHighWaterMark">
+            <property name="text">
+             <string>SD card information</string>
+            </property>
             <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             <set>Qt::AlignCenter</set>
             </property>
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+           <widget class="QFrame" name="rd_frame">
+            <property name="frameShape">
+             <enum>QFrame::Box</enum>
             </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>End at % of SD size:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
-          <item>
-           <widget class="QSpinBox" name="EndBlockSpin">
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
+            <layout class="QHBoxLayout" name="horizontalLayout_5">
+             <item>
+              <widget class="QLabel" name="l_sd_size">
+               <property name="text">
+                <string>SD size: %1GB</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_5">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_5">
+               <property name="text">
+                <string>Unit:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="rd_percent">
+               <property name="text">
+                <string>%</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="rd_MB">
+               <property name="text">
+                <string>MB</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="rd_GB">
+               <property name="text">
+                <string>GB</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+           <layout class="QHBoxLayout" name="StartControls">
+            <item>
+             <widget class="QLabel" name="l_sd_start">
+              <property name="text">
+               <string>Start at %1 of SD size:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="StartBlockSpin">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="maximum">
+               <double>999999999999999983222784.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="StopControls">
+            <item>
+             <widget class="QLabel" name="l_sd_end">
+              <property name="text">
+               <string>End at %1 of SD size:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="EndBlockSpin">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="maximum">
+               <double>99999999999999997748809823456034029568.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QLabel" name="l_rounding_info">
+            <property name="text">
+             <string>Size will be rounded to integral percent of total card size (%1MB)</string>
             </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
+           </widget>
           </item>
          </layout>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QFormLayout" name="formLayout_2">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Password:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="HVPasswordEdit">
-          <property name="text">
-           <string>12345678901234567890</string>
-          </property>
-          <property name="echoMode">
-           <enum>QLineEdit::Password</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QCheckBox" name="ShowPasswordCheckBox">
-          <property name="text">
-           <string>Show password</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QLineEdit" name="HVPasswordEdit_2">
-          <property name="focusPolicy">
-           <enum>Qt::ClickFocus</enum>
-          </property>
-          <property name="echoMode">
-           <enum>QLineEdit::Password</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Password:</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QVBoxLayout" name="verticalLayout">
-        <item>
-         <widget class="QLabel" name="HVEntropieLabel">
-          <property name="text">
-           <string>Entropy guess:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="HVEntropieRandChars">
-          <property name="text">
-           <string> bits for random chars</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="HVEntropieRealWords">
-          <property name="text">
-           <string> for real words</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+        </widget>
+       </widget>
       </item>
      </layout>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Minimum</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item>
     <widget class="Line" name="line">
@@ -259,7 +419,7 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="bottom_buttons">
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
@@ -289,12 +449,7 @@
  </widget>
  <tabstops>
   <tabstop>HVPasswordEdit</tabstop>
-  <tabstop>HVPasswordEdit_2</tabstop>
-  <tabstop>StartBlockSpin</tabstop>
-  <tabstop>EndBlockSpin</tabstop>
-  <tabstop>comboBox</tabstop>
   <tabstop>ShowPasswordCheckBox</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources>
   <include location="../resources.qrc"/>

--- a/ui/stick20hiddenvolumedialog.ui
+++ b/ui/stick20hiddenvolumedialog.ui
@@ -103,14 +103,14 @@
            <item>
             <widget class="QLabel" name="HVEntropieLabel">
              <property name="text">
-              <string>Entropy guess:</string>
+              <string>Entropy guess (assuming no dictionary words were used)</string>
              </property>
             </widget>
            </item>
            <item>
             <widget class="QLabel" name="HVEntropieRealWords">
              <property name="text">
-              <string> for real words</string>
+              <string>using human readable symbols: </string>
              </property>
             </widget>
            </item>
@@ -415,7 +415,7 @@
           <item>
            <widget class="QLabel" name="l_rounding_info">
             <property name="text">
-             <string>Size will be rounded to integral percent of total card size (%1MB)</string>
+             <string>Size will be rounded down to integral percent of total card size (%1MB)</string>
             </property>
            </widget>
           </item>

--- a/ui/stick20hiddenvolumedialog.ui
+++ b/ui/stick20hiddenvolumedialog.ui
@@ -78,7 +78,7 @@
          <item row="1" column="1">
           <widget class="QLineEdit" name="HVPasswordEdit_2">
            <property name="focusPolicy">
-            <enum>Qt::ClickFocus</enum>
+            <enum>Qt::StrongFocus</enum>
            </property>
            <property name="text">
             <string notr="true">12345678901234567890</string>
@@ -135,6 +135,9 @@
                <property name="enabled">
                 <bool>false</bool>
                </property>
+               <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
+               </property>
                <property name="text">
                 <string>length</string>
                </property>
@@ -145,6 +148,9 @@
                <property name="enabled">
                 <bool>false</bool>
                </property>
+               <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
+               </property>
                <property name="text">
                 <string>lower case</string>
                </property>
@@ -154,6 +160,9 @@
               <widget class="QCheckBox" name="cb_upper_case">
                <property name="enabled">
                 <bool>false</bool>
+               </property>
+               <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
                </property>
                <property name="text">
                 <string>upper case</string>
@@ -168,6 +177,9 @@
                <property name="enabled">
                 <bool>false</bool>
                </property>
+               <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
+               </property>
                <property name="text">
                 <string>numbers</string>
                </property>
@@ -177,6 +189,9 @@
               <widget class="QCheckBox" name="cb_symbols">
                <property name="enabled">
                 <bool>false</bool>
+               </property>
+               <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
                </property>
                <property name="text">
                 <string>symbols</string>
@@ -449,7 +464,14 @@
  </widget>
  <tabstops>
   <tabstop>HVPasswordEdit</tabstop>
+  <tabstop>HVPasswordEdit_2</tabstop>
   <tabstop>ShowPasswordCheckBox</tabstop>
+  <tabstop>comboBox</tabstop>
+  <tabstop>rd_percent</tabstop>
+  <tabstop>rd_MB</tabstop>
+  <tabstop>rd_GB</tabstop>
+  <tabstop>StartBlockSpin</tabstop>
+  <tabstop>EndBlockSpin</tabstop>
  </tabstops>
  <resources>
   <include location="../resources.qrc"/>

--- a/ui/stick20hiddenvolumedialog.ui
+++ b/ui/stick20hiddenvolumedialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>430</width>
-    <height>503</height>
+    <height>574</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -43,7 +43,49 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QLabel" name="label_2">
+       <layout class="QHBoxLayout" name="top_layout">
+        <item>
+         <widget class="QLabel" name="l_warning">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="pixmap">
+           <pixmap resource="../resources.qrc">:/images/warning.png</pixmap>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="l_top_instructions">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;You should understand the properties of hidden volumes before proceeding. It can destroy your encrypted data! &lt;br/&gt;Please read &lt;/span&gt;&lt;a href=&quot;https://www.nitrokey.com/documentation/hidden-volumes&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline; color:#0000ff;&quot;&gt;these instructions&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-weight:600;&quot;&gt; first.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="scaledContents">
+           <bool>false</bool>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QLabel" name="l_instructions">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -51,15 +93,9 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You should understand the properties of hidden volumes before proceeding. &lt;br/&gt;Please read &lt;a href=&quot;https://www.nitrokey.com/documentation/hidden-volumes&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;these instructions&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="scaledContents">
-         <bool>false</bool>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;1. You may want to copy some innocuous files to the encrypted data.&lt;br/&gt;2. Configure hidden volumes in this dialogue. &lt;br/&gt;3. Once you configured a hidden volume you must not use/write to the encryption volume anymore. Otherwise it may destroy the data in your hidden volume.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="openExternalLinks">
          <bool>true</bool>
         </property>
        </widget>
@@ -122,20 +158,6 @@
          </item>
          <item row="3" column="0" colspan="2">
           <layout class="QVBoxLayout" name="entropy_verticalLayout">
-           <item>
-            <widget class="QLabel" name="HVEntropieLabel">
-             <property name="text">
-              <string>Entropy guess (assuming no dictionary words were used)</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="HVEntropieRealWords">
-             <property name="text">
-              <string>using human readable symbols: </string>
-             </property>
-            </widget>
-           </item>
            <item>
             <widget class="QLabel" name="label_6">
              <property name="text">
@@ -284,7 +306,7 @@
             <item>
              <widget class="QLabel" name="HVSdCardHighWaterMark">
               <property name="text">
-               <string>SD card information</string>
+               <string notr="true">SD card information</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignCenter</set>
@@ -300,7 +322,7 @@
                <item>
                 <widget class="QLabel" name="l_sd_size">
                  <property name="text">
-                  <string>SD size: %1GB</string>
+                  <string notr="true">Storage capacity: %1GB</string>
                  </property>
                 </widget>
                </item>
@@ -353,7 +375,7 @@
               <item>
                <widget class="QLabel" name="l_sd_start">
                 <property name="text">
-                 <string>Start at %1 of SD size:</string>
+                 <string notr="true">Start at %1 of SD size:</string>
                 </property>
                </widget>
               </item>
@@ -393,7 +415,7 @@
               <item>
                <widget class="QLabel" name="l_sd_end">
                 <property name="text">
-                 <string>End at %1 of SD size:</string>
+                 <string notr="true">End at %1 of SD size:</string>
                 </property>
                </widget>
               </item>
@@ -443,7 +465,7 @@
                </size>
               </property>
               <property name="text">
-               <string>Size will be rounded down to integral percent of total card size (%1MB)</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Size will be rounded down to integral percent of total storage size (%1MB)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>

--- a/ui/stick20hiddenvolumedialog.ui
+++ b/ui/stick20hiddenvolumedialog.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>526</width>
-    <height>486</height>
+    <width>430</width>
+    <height>503</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -42,6 +42,28 @@
       <enum>QFrame::Plain</enum>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QLabel" name="label_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You should understand the properties of hidden volumes before proceeding. &lt;br/&gt;Please read &lt;a href=&quot;https://www.nitrokey.com/documentation/hidden-volumes&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;these instructions&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="scaledContents">
+         <bool>false</bool>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
       <item>
        <widget class="QGroupBox" name="password_group">
         <property name="title">
@@ -409,15 +431,15 @@
             <item>
              <widget class="QLabel" name="l_rounding_info">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
               <property name="minimumSize">
                <size>
-                <width>100</width>
-                <height>100</height>
+                <width>0</width>
+                <height>0</height>
                </size>
               </property>
               <property name="text">

--- a/ui/stick20hiddenvolumedialog.ui
+++ b/ui/stick20hiddenvolumedialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>430</width>
-    <height>452</height>
+    <width>526</width>
+    <height>486</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -225,202 +225,210 @@
         <property name="checkable">
          <bool>false</bool>
         </property>
-        <widget class="QFrame" name="verticalFrame">
-         <property name="geometry">
-          <rect>
-           <x>9</x>
-           <y>20</y>
-           <width>381</width>
-           <height>151</height>
-          </rect>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_6">
-          <item>
-           <widget class="QComboBox" name="comboBox">
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QFrame" name="verticalFrame">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_6">
             <item>
-             <property name="text">
-              <string>Hidden volume slot 1</string>
-             </property>
+             <widget class="QComboBox" name="comboBox">
+              <item>
+               <property name="text">
+                <string>Hidden volume slot 1</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Hidden volume slot 2</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Hidden volume slot 3</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Hidden volume slot 4</string>
+               </property>
+              </item>
+             </widget>
             </item>
             <item>
-             <property name="text">
-              <string>Hidden volume slot 2</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Hidden volume slot 3</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Hidden volume slot 4</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="HVSdCardHighWaterMark">
-            <property name="text">
-             <string>SD card information</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QFrame" name="rd_frame">
-            <property name="frameShape">
-             <enum>QFrame::Box</enum>
-            </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_5">
-             <item>
-              <widget class="QLabel" name="l_sd_size">
-               <property name="text">
-                <string>SD size: %1GB</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_5">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_5">
-               <property name="text">
-                <string>Unit:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QRadioButton" name="rd_percent">
-               <property name="text">
-                <string>%</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QRadioButton" name="rd_MB">
-               <property name="text">
-                <string>MB</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QRadioButton" name="rd_GB">
-               <property name="text">
-                <string>GB</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="StartControls">
-            <item>
-             <widget class="QLabel" name="l_sd_start">
+             <widget class="QLabel" name="HVSdCardHighWaterMark">
               <property name="text">
-               <string>Start at %1 of SD size:</string>
+               <string>SD card information</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
               </property>
              </widget>
             </item>
             <item>
-             <spacer name="horizontalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+             <widget class="QFrame" name="rd_frame">
+              <property name="frameShape">
+               <enum>QFrame::Box</enum>
               </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
+              <layout class="QHBoxLayout" name="horizontalLayout_5">
+               <item>
+                <widget class="QLabel" name="l_sd_size">
+                 <property name="text">
+                  <string>SD size: %1GB</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_5">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_5">
+                 <property name="text">
+                  <string>Unit:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QRadioButton" name="rd_percent">
+                 <property name="text">
+                  <string>%</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QRadioButton" name="rd_MB">
+                 <property name="text">
+                  <string>MB</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QRadioButton" name="rd_GB">
+                 <property name="text">
+                  <string>GB</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
             </item>
             <item>
-             <widget class="QDoubleSpinBox" name="StartBlockSpin">
+             <layout class="QHBoxLayout" name="StartControls">
+              <item>
+               <widget class="QLabel" name="l_sd_start">
+                <property name="text">
+                 <string>Start at %1 of SD size:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_2">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QDoubleSpinBox" name="StartBlockSpin">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="maximum">
+                 <double>999999999999999983222784.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="StopControls">
+              <item>
+               <widget class="QLabel" name="l_sd_end">
+                <property name="text">
+                 <string>End at %1 of SD size:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_3">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QDoubleSpinBox" name="EndBlockSpin">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="maximum">
+                 <double>99999999999999997748809823456034029568.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QLabel" name="l_rounding_info">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="maximum">
-               <double>999999999999999983222784.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="StopControls">
-            <item>
-             <widget class="QLabel" name="l_sd_end">
-              <property name="text">
-               <string>End at %1 of SD size:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_3">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
+              <property name="minimumSize">
                <size>
-                <width>40</width>
-                <height>20</height>
+                <width>100</width>
+                <height>100</height>
                </size>
               </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QDoubleSpinBox" name="EndBlockSpin">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="maximum">
-               <double>99999999999999997748809823456034029568.000000000000000</double>
+              <property name="text">
+               <string>Size will be rounded down to integral percent of total card size (%1MB)</string>
               </property>
              </widget>
             </item>
            </layout>
-          </item>
-          <item>
-           <widget class="QLabel" name="l_rounding_info">
-            <property name="text">
-             <string>Size will be rounded down to integral percent of total card size (%1MB)</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
Fixes #72 
Tested on Ubuntu 16.04
- Adds visual password strength indicator
- Allows to input hidden volume size also in MB and GB (instead of only `%`)
- Fixed tab stops
- Improved general layout, added instructions and warnings