### PR TITLE
Build package on launchpad 2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: nitrokey-app
 Section: universe/utils
 Priority: optional
 Maintainer: Jan Suhr <jan@nitrokey.com>
-Build-Depends: debhelper (>= 9), libqt5core5a, libqt5dbus5, libqt5gui5, libqt5widgets5, libqt5xml5, qt5-qmake, qtbase5-dev-tools, libusb-1.0-0-dev, libgtk2.0-dev, libappindicator-dev, libnotify-dev
+Build-Depends: debhelper (>= 9), qtchooser, libqt5core5a, libqt5dbus5, libqt5gui5, libqt5widgets5, libqt5xml5, qt5-qmake, qtbase5-dev-tools, qtbase5-dev, libusb-1.0-0-dev, libgtk2.0-dev, libappindicator-dev, libnotify-dev
 Standards-Version: 3.9.7
 Homepage: https://www.nitrokey.com
 

--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: nitrokey-app
 Section: utils
 Priority: optional
 Maintainer: Jan Suhr <jan@nitrokey.com>
-Build-Depends: debhelper (>= 9), qt5-base, libusb-1.0-0-dev, libgtk2.0-dev, libappindicator-dev, libnotify-dev
+Build-Depends: debhelper (>= 9), libqt5core5a, libqt5dbus5, libqt5gui5, libqt5widgets5, libqt5xml5, qt5-qmake, qtbase5-dev-tools, libusb-1.0-0-dev, libgtk2.0-dev, libappindicator-dev, libnotify-dev
 Standards-Version: 3.9.7
 Homepage: https://www.nitrokey.com
 
 Package: nitrokey-app
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, qt5-base, libusb-1.0-0, libappindicator1, libnotify4
+Depends: ${shlibs:Depends}, ${misc:Depends}, libqt5core5a, libqt5dbus5, libqt5gui5, libqt5widgets5, libqt5xml5, libusb-1.0-0, libappindicator1, libnotify4
 Description: Nitrokey App for usage with Nitro Key Pro
  The Nitrokey App is required for Nitrokey Pro and Nitrokey Storage.
  It offers Google Authenticator compatible One-Time-Passwords and

--- a/debian/control
+++ b/debian/control
@@ -1,5 +1,5 @@
 Source: nitrokey-app
-Section: utils
+Section: universe/utils
 Priority: optional
 Maintainer: Jan Suhr <jan@nitrokey.com>
 Build-Depends: debhelper (>= 9), libqt5core5a, libqt5dbus5, libqt5gui5, libqt5widgets5, libqt5xml5, qt5-qmake, qtbase5-dev-tools, libusb-1.0-0-dev, libgtk2.0-dev, libappindicator-dev, libnotify-dev

--- a/debian/rules
+++ b/debian/rules
@@ -1,22 +1,25 @@
 #!/usr/bin/make -f
 
 export DEB_BUILD_HARDENING=1
+export QT_SELECT=qt5
 
 clean:
+	-rm build
 	dh_testdir
-	dh_testroot
-	qmake
+	qmake -qt=qt5
 	make clean
 	dh_clean -A
+
+build:
+	qmake -qt=qt5
+	make
+	touch build
 
 binary:
 	dh_testdir
 	dh_testroot
 	dh_prep
 	dh_installdirs
-
-	qmake
-	make
 
 	install -m755 nitrokey-app debian/nitrokey-app/usr/bin/nitrokey-app
 
@@ -55,4 +58,4 @@ binary-indep: binary
 build-arch: build
 build-indep: build
 
-build: binary
+.PHONY: clean binary


### PR DESCRIPTION
Move package to universe and use qt5-base subcomponents instead of meta package.