### PR TITLE
/usr/lib/udev(/rules.d) makes RPM unhappy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,8 @@ LIST(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
     "/etc/bash_completion.d"
     "/etc/udev"
     "/etc/udev/rules.d"
+    "/usr/lib/udev"
+    "/usr/lib/udev/rules.d"
     "/usr/share/locale"
     "/usr/share/locale/de_DE"
     "/usr/share/locale/de_DE/LC_MESSAGES"
@@ -341,6 +343,6 @@ LIST(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
     "/usr/share/icons/ubuntu-mono-light/apps/16"
     "/usr/share/applications"
     "/usr/share/pixmaps"
-)
+    )
 
-INCLUDE(CPack)
+  INCLUDE(CPack)


### PR DESCRIPTION
These directories should not be in the spec file for RPM. It complains of conflicts on install.
/usr/lib/udev
/usr/lib/udev/rules.d