### PR TITLE
Remove locations from translation files

### DIFF
--- a/i18n/nitrokey_de_DE.ts
+++ b/i18n/nitrokey_de_DE.ts
@@ -4,7 +4,6 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="23"/>
         <source>About</source>
         <translation>Über</translation>
     </message>
@@ -13,7 +12,6 @@
         <translation type="obsolete">Nitrokey App</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="53"/>
         <source>ICON</source>
         <translation></translation>
     </message>
@@ -22,29 +20,22 @@
         <translation type="obsolete">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Dieses Programm dient zum konfigurieren und verwenden des Nitrokeys.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://www.nitrokey.com&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;www.nitrokey.com&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://www.nitrokey.com/start&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Anleitung und Hilfe&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="79"/>
         <source>i</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="127"/>
         <source>App version:</source>
         <translation>App Version:</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="164"/>
         <source>Firmware version:</source>
         <translation>Firmware Version:</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="201"/>
         <source>Card serial number:</source>
         <translation>Karten-Seriennummer:</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="140"/>
-        <location filename="../ui/aboutdialog.ui" line="177"/>
-        <location filename="../ui/aboutdialog.ui" line="214"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
@@ -53,34 +44,28 @@
         <translation type="vanished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mit diesem Programm können Sie den Nitrokey konfigurieren und nutzen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="86"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://www.nitrokey.com/start&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#c80636;&quot;&gt;Instructions and help&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://www.nitrokey.com/start&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#c80636;&quot;&gt;Anleitungen und Hilfe&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="254"/>
         <source>Status</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="347"/>
         <source>Hidden Volume:</source>
         <translation>Versteckte Volumen:</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="486"/>
         <source>&lt;span style=&quot;color:#c80636&quot;&gt;Warning&lt;/span&gt;</source>
         <translation>&lt;span style=&quot;color:#c80636&quot;&gt;Warnung&lt;/span&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="511"/>
         <source>Stick is not secure!
 Select Init keys.</source>
         <translation>Gerät ist nicht sicher!
 Initialisieren Sie die Schlüssel.</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="569"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-style:italic;&quot;&gt;Copyright 2016 by NitrokeyUG. &lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-style:italic;&quot;&gt;This software is licensed under the &lt;/span&gt;&lt;a href=&quot;https://www.gnu.org/licenses/&quot;&gt;&lt;span style=&quot; font-size:10pt; font-style:italic; text-decoration: underline; color:#c80636;&quot;&gt;GNU General Public License v3&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt; font-style:italic;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://nitrokey.com&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#c80636;&quot;&gt;www.nitrokey.com&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-style:italic;&quot;&gt;Copyright 2016 durch NitrokeyUG. &lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-style:italic;&quot;&gt;Diese Software ist unter der &lt;/span&gt;&lt;a href=&quot;https://www.gnu.org/licenses/&quot;&gt;&lt;span style=&quot; font-size:10pt; font-style:italic; text-decoration: underline; color:#c80636;&quot;&gt;GNU General Public License v3&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt; font-style:italic;&quot;&gt; lizensiert.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://www.nitrokey.com&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#c80636;&quot;&gt;www.nitrokey.com&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -89,47 +74,38 @@ Initialisieren Sie die Schlüssel.</translation>
         <translation type="vanished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-style:italic;&quot;&gt;Urheberrecht 2014 bei Nitrokey. &lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-style:italic;&quot;&gt;Diese Software ist unter der &lt;/span&gt;&lt;a href=&quot;https://www.gnu.org/licenses/&quot;&gt;&lt;span style=&quot; font-size:10pt; font-style:italic; text-decoration: underline; color:#c80636;&quot;&gt;GNU General Public License v3&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt; font-style:italic;&quot;&gt;lizensiert.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://www.nitrokey.com&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#c80636;&quot;&gt;www.nitrokey.com&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="442"/>
         <source>New SD card found</source>
         <translation>Neue SD-Karte gefunden</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="454"/>
         <source>(Not erased with random data)</source>
         <translation>(Nicht mit Zufallsdaten gelöscht)</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="287"/>
         <source>SD ID:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="64"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This application allows you to configure and use the Nitrokey Pro and Nitrokey Storage.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dieses Programm dient zum Konfigurieren und Verwenden des Nitrokey Pro und Nitrokey Storage.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="307"/>
         <source>Unencrypted volume:</source>
         <translation>Unverschlüsseltes Volumen:</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="327"/>
         <source>Encrypted volume:</source>
         <translation>Verschlüsseltes Volumen:</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="425"/>
         <source>Password retry counters:</source>
         <translation>Passwort-Eingabe-Zähler:</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="391"/>
         <source>Admin:</source>
         <translation>Administrator:</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="398"/>
         <source>User:</source>
         <translation>Benutzer:</translation>
     </message>
@@ -138,17 +114,14 @@ Initialisieren Sie die Schlüssel.</translation>
         <translation type="obsolete">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-style:italic;&quot;&gt;Urheberrechtlich geschützt 2015 durch Nitrokey. Diese Software ist unter der &lt;/span&gt;&lt;a href=&quot;https://www.gnu.org/licenses/&quot;&gt;&lt;span style=&quot; font-size:10pt; font-style:italic; text-decoration: underline; color:#0000ff;&quot;&gt;GNU General Public License v3&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt; font-style:italic;&quot;&gt; lizensiert.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="609"/>
         <source>Detailed Status</source>
         <translation>Detaillierter Status</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="619"/>
         <source>OK</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/aboutdialog.cpp" line="102"/>
         <source>
 SD card is not accessible
 
@@ -159,7 +132,6 @@ Kann nicht auf SD-Karte zugreifen
 </translation>
     </message>
     <message>
-        <location filename="../src/ui/aboutdialog.cpp" line="108"/>
         <source>
 Smartcard is not accessible
 
@@ -170,31 +142,24 @@ Kann nicht auf Chipkarte zugreifen
 </translation>
     </message>
     <message>
-        <location filename="../src/ui/aboutdialog.cpp" line="118"/>
         <source>No connection
 Please retry</source>
         <translation>Keine Verbindung
 Bitte versuchen Sie es erneut</translation>
     </message>
     <message>
-        <location filename="../src/ui/aboutdialog.cpp" line="147"/>
         <source>READ/WRITE</source>
         <translation>LESEN/SCHREIBEN</translation>
     </message>
     <message>
-        <location filename="../src/ui/aboutdialog.cpp" line="149"/>
         <source>READ ONLY</source>
         <translation>NUR-LESEN</translation>
     </message>
     <message>
-        <location filename="../src/ui/aboutdialog.cpp" line="153"/>
-        <location filename="../src/ui/aboutdialog.cpp" line="158"/>
         <source>Active</source>
         <translation>aktiv</translation>
     </message>
     <message>
-        <location filename="../src/ui/aboutdialog.cpp" line="155"/>
-        <location filename="../src/ui/aboutdialog.cpp" line="160"/>
         <source>Not active</source>
         <translation>inaktiv</translation>
     </message>
@@ -253,7 +218,6 @@ Bitte versuchen Sie es erneut</translation>
         <translation type="obsolete">Benutzer  : </translation>
     </message>
     <message>
-        <location filename="../src/ui/aboutdialog.cpp" line="302"/>
         <source>No active Nitrokey
 
 </source>
@@ -265,32 +229,26 @@ Bitte versuchen Sie es erneut</translation>
 <context>
     <name>DebugDialog</name>
     <message>
-        <location filename="../ui/stick20debugdialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Dialog</translation>
     </message>
     <message>
-        <location filename="../ui/stick20debugdialog.ui" line="41"/>
         <source>Output GUI</source>
         <translation>Ausgabe GUI</translation>
     </message>
     <message>
-        <location filename="../ui/stick20debugdialog.ui" line="54"/>
         <source>Update</source>
         <translation>Aktualisierung</translation>
     </message>
     <message>
-        <location filename="../ui/stick20debugdialog.ui" line="80"/>
         <source>Auto update</source>
         <translation>Automatische Aktualisierung</translation>
     </message>
     <message>
-        <location filename="../ui/stick20debugdialog.ui" line="120"/>
         <source>Device Output</source>
         <translation>Geräteausgabe</translation>
     </message>
     <message>
-        <location filename="../ui/stick20debugdialog.ui" line="133"/>
         <source>Device output logged via USB</source>
         <translation>Geräteausgabe mittels USB protokolliert</translation>
     </message>
@@ -298,38 +256,30 @@ Bitte versuchen Sie es erneut</translation>
 <context>
     <name>DialogChangePassword</name>
     <message>
-        <location filename="../ui/stick20changepassworddialog.ui" line="26"/>
         <source>Change user PIN</source>
         <translation>Ändere Benutzer-PIN</translation>
     </message>
     <message>
-        <location filename="../ui/stick20changepassworddialog.ui" line="59"/>
         <source>Old PIN</source>
         <translation>Alte PIN</translation>
     </message>
     <message>
-        <location filename="../ui/stick20changepassworddialog.ui" line="72"/>
-        <location filename="../ui/stick20changepassworddialog.ui" line="85"/>
         <source>New PIN</source>
         <translation>Neue PIN</translation>
     </message>
     <message>
-        <location filename="../ui/stick20changepassworddialog.ui" line="98"/>
         <source>Show PIN</source>
         <translation>PIN anzeigen</translation>
     </message>
     <message>
-        <location filename="../ui/stick20changepassworddialog.ui" line="110"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;You can use upper and lower case, numbers, and special characters.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Sie können Groß- und Kleinbuchstaben, Zahlen und Sonderzeichen verwenden.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/stick20changepassworddialog.ui" line="132"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;PINs can only be tried three times and are secure against brute force guessing. A PIN of 6 or 8 digits is sufficiently long and longer or more complex PINs are usually unnecessary. The minimum length is %1 (%3 for admin) and the maximum length is %2 chars. &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;PINs können nur dreimal ausprobiert werden und sind daher sicher gegen Brute Force Angriffe. Eine PIN mit 6 oder 8 Zahlen ist ausreichend lang so dass längere und kompliziere PINs in der Regel unnötig sind. Die minimale Länge beträgt %1 (%3 für Admin) und die maximale Länge beträgt %2 Zeichen. &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/stick20changepassworddialog.ui" line="147"/>
         <source>Retry count left:</source>
         <translation type="unfinished">Anzahl möglicher Versuche:</translation>
     </message>
@@ -354,7 +304,6 @@ Bitte versuchen Sie es erneut</translation>
         <translation type="vanished">Benutzer-PIN zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="152"/>
         <source>Admin PIN:</source>
         <translation>Administrator-PIN:</translation>
     </message>
@@ -379,7 +328,6 @@ Bitte versuchen Sie es erneut</translation>
         <translation type="obsolete">Neues Aktualisierungs-Passwort (Wiederholung):</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="157"/>
         <source>Change Firmware Password</source>
         <translation>Firmware-Passwort ändern</translation>
     </message>
@@ -388,8 +336,6 @@ Bitte versuchen Sie es erneut</translation>
         <translation type="vanished">Firmware-Passwort:</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="159"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="160"/>
         <source>New Firmware Password:</source>
         <translation>Neues Firmware-Passwort:</translation>
     </message>
@@ -398,166 +344,126 @@ Bitte versuchen Sie es erneut</translation>
         <translation type="vanished">Neues Firmware-Passwort (Wiederholung):</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="86"/>
         <source>Unfortunately you have no more trials left. Please use &apos;Reset User PIN&apos; option from menu to reset password</source>
         <translation type="unfinished">Leider sind keine Eingaben mehr möglich. Bitte nutzen Sie die Option &quot;Reset Benutzer-PIN&quot; im Menü um Ihre PIN zurückzusetzen</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="94"/>
         <source>Unfortunately you have no more trials left. Please check instruction how to reset Admin password.</source>
         <translation type="unfinished">Leider sind keine Eingaben mehr möglich. Bitte lesen Sie die Dokumentation wie die Admin-PIN zurückgesetzt werden kann.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="126"/>
         <source>Once the firmware password is forgotten the Nitrokey can&apos;t be updated or reset. Don&apos;t lose your firmware password, please.</source>
         <translation>Wenn das Firmware-Passwort vergessen wurde, kann der Nitrokey nicht mehr aktualisiert oder zurückgesetzt werden. Bitte verlieren Sie Ihr Firmware-Passwort nicht.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="137"/>
         <source>Set User PIN</source>
         <translation type="unfinished">Setze Benutzer-PIN</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="138"/>
         <source>Current User PIN:</source>
         <translation type="unfinished">Aktuelle Benutzer-PIN:</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="139"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="140"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="153"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="154"/>
         <source>New User PIN:</source>
         <translation type="unfinished">Neue Benutzer-PIN:</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="144"/>
         <source>Set Admin PIN</source>
         <translation type="unfinished">Setze Admin-PIN</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="145"/>
         <source>Current Admin PIN:</source>
         <translation type="unfinished">Aktuelle Admin-PIN:</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="146"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="147"/>
         <source>New Admin PIN:</source>
         <translation type="unfinished">Neue Admin-PIN:</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="151"/>
         <source>Reset User PIN</source>
         <translation type="unfinished">Benutzer-PIN zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="158"/>
         <source>Current Firmware Password:</source>
         <translation type="unfinished">Aktuelles Firmware-Passwort:</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="161"/>
         <source>Show password</source>
         <translation>Passwort anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="202"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="220"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="284"/>
         <source>There was a problem during communicating with device. Please retry.</source>
         <translation>Bei der Gerätekommunikation ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="208"/>
         <source>Current password is not correct. Please retry.</source>
         <translation type="unfinished">Aktuelles Passwort ist falsch. Bitte versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="226"/>
         <source>New password is not correct. Please retry.</source>
         <translation type="unfinished">Neues Passwort ist falsch. Bitte versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="229"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="264"/>
         <source>New password is set</source>
         <translation type="unfinished">Neues Passwort wurde gesetzt</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="257"/>
         <source>Wrong password.</source>
         <translation>Falsches Passwort.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="259"/>
         <source>Couldn&apos;t change %1 password</source>
         <translation>Konnte %1 Passwort nicht ändern</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="290"/>
         <source>Current Admin password is not correct. Please retry.</source>
         <translation type="unfinished">Aktuelles Admin-Passwort ist falsch. Bitte versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="300"/>
         <source>There was a problem during communicating with device or new password is not correct. Please retry.</source>
         <translation type="unfinished">Bei der Gerätekommunikation ist ein Fehler aufgetreten oder das neue Passwort ist falsch. Bitte versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="305"/>
         <source>New User password is set</source>
         <translation type="unfinished">Neue Benutzer-PIN wurde gesetzt</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="329"/>
         <source>Wrong Admin PIN.</source>
         <translation>Falsche Administrator-PIN.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="331"/>
         <source>Couldn&apos;t unblock the user PIN. Error: %1</source>
         <translation>Benutzer-PIN konnte nicht freigeschaltet werden. Fehler: %1</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="334"/>
         <source>User PIN successfully unblocked</source>
         <translation>Benutzer-PIN erfolgreich freigeschaltet</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="361"/>
         <source>Wrong password or there was a communication problem with the device.</source>
         <translation type="unfinished">Falsches Passwort oder Kommunikationsproblem mit dem Gerät.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="364"/>
         <source>Password has been changed with success!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="374"/>
         <source>The minimum length of the old password is </source>
         <translation>Minimale Länge des alten Passworts ist </translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="375"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="397"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="409"/>
         <source> chars</source>
         <translation> Zeichen</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="385"/>
         <source>The new password entrys are not the same</source>
         <translation>Die neuen Passwörter sind nicht identisch</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="396"/>
         <source>The maximum length of a password is </source>
         <translation>Maximale Passwortlänge beträgt </translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="408"/>
         <source>The minimum length of a password is </source>
         <translation>Minimale Passwortlänge beträgt </translation>
     </message>
@@ -565,66 +471,50 @@ Bitte versuchen Sie es erneut</translation>
 <context>
     <name>HOTPDialog</name>
     <message>
-        <location filename="../ui/hotpdialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Dialog</translation>
     </message>
     <message>
-        <location filename="../ui/hotpdialog.ui" line="43"/>
-        <location filename="../src/ui/hotpdialog.cpp" line="96"/>
         <source>Your HOTP:</source>
         <translation>Ihr HOTP:</translation>
     </message>
     <message>
-        <location filename="../ui/hotpdialog.ui" line="56"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../ui/hotpdialog.ui" line="69"/>
         <source>Get next</source>
         <translation>Nächster</translation>
     </message>
     <message>
-        <location filename="../ui/hotpdialog.ui" line="101"/>
         <source>TOTP interval:</source>
         <translation>TOTP Intervall:</translation>
     </message>
     <message>
-        <location filename="../ui/hotpdialog.ui" line="114"/>
-        <location filename="../src/ui/hotpdialog.cpp" line="177"/>
-        <location filename="../src/ui/hotpdialog.cpp" line="181"/>
         <source>Valid</source>
         <translation>Gültig</translation>
     </message>
     <message>
-        <location filename="../ui/hotpdialog.ui" line="138"/>
-        <location filename="../src/ui/hotpdialog.cpp" line="98"/>
         <source>HOTP copied to clipboard</source>
         <translation>HOTP wurde in die Zwischenablage kopiert</translation>
     </message>
     <message>
-        <location filename="../src/ui/hotpdialog.cpp" line="97"/>
         <source>Next HOTP</source>
         <translation>Nächster HOTP</translation>
     </message>
     <message>
-        <location filename="../src/ui/hotpdialog.cpp" line="106"/>
         <source>Your TOTP:</source>
         <translation>Ihr TOTP:</translation>
     </message>
     <message>
-        <location filename="../src/ui/hotpdialog.cpp" line="107"/>
         <source>Generate TOTP</source>
         <translation>Generiere TOTP</translation>
     </message>
     <message>
-        <location filename="../src/ui/hotpdialog.cpp" line="110"/>
         <source>TOTP copied to clipboard</source>
         <translation>TOTP wurde in die Zwischenablage kopiert</translation>
     </message>
     <message>
-        <location filename="../src/ui/hotpdialog.cpp" line="185"/>
         <source>Invalid</source>
         <translation>Ungültig</translation>
     </message>
@@ -632,171 +522,134 @@ Bitte versuchen Sie es erneut</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../ui/mainwindow.ui" line="20"/>
         <source>Configuration</source>
         <translation>Konfiguration</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="65"/>
         <source>OTP Slot Configuration</source>
         <translation>Einmalpasswörter-Einträge</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="89"/>
         <source>Manage slots</source>
         <translation>Einmalpasswörter allgemein</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="98"/>
         <source>TOTP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="108"/>
         <source>HOTP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="120"/>
         <source>(Recommendation: Use TOTP for web applications and HOTP for local applications)</source>
         <translation>(Tipp: Verwenden Sie TOTP für Webseiten und HOTP für lokale Programme)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="144"/>
-        <location filename="../ui/mainwindow.ui" line="1236"/>
         <source>Slot:</source>
         <translation>Eintrag:</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="155"/>
         <source>HOTP slot 1</source>
         <translation>HOTP Eintrag 1</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="160"/>
         <source>HOTP slot 2</source>
         <translation>HOTP Eintrag 2</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="165"/>
         <source>TOTP slot 1</source>
         <translation>TOTP Eintrag 1</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="170"/>
         <source>TOTP slot 2</source>
         <translation>TOTP Eintrag 2</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="175"/>
         <source>TOTP slot 3</source>
         <translation>TOTP Eintrag 3</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="180"/>
         <source>TOTP slot 4</source>
         <translation>TOTP Eintrag 4</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="188"/>
-        <location filename="../ui/mainwindow.ui" line="1203"/>
         <source>Erase Slot</source>
         <translation>Eintrag löschen</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="195"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="235"/>
         <source>Secret key</source>
         <translation>Geheimer Schlüssel</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="254"/>
-        <location filename="../ui/mainwindow.ui" line="266"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The secret is provided by your service provider you may want to login or can be configured in your local application which you may want to login to.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Das Geheimnis wird durch Ihren Dienstanbieter bereitgestellt oder kann in Ihrer lokalen Anwendung konfiguriert werden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="257"/>
         <source>Secret Key:</source>
         <translation>Geheimnis:</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="281"/>
         <source>********************************</source>
         <translation>********************************</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="296"/>
         <source>Secret copied to clipboard</source>
         <translation>Geheimnis in Zwischenablage kopiert</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="308"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide or show the secret.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Geheimnis verstecken oder anzeigen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="311"/>
-        <location filename="../ui/mainwindow.ui" line="1246"/>
         <source>Hide secret</source>
         <translation>Geheimnis verstecken</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="334"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;After generating a random secret, you would need to copy it into your application or service where you want to login to.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nach der Generierung eines zufälligen Geheimnisses sollten Sie dieses in Ihre Anwendung oder Webdienst kopieren, an dem Sie sich anmelden möchten.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="337"/>
         <source>Generate random secret</source>
         <translation>Zufälliges Geheimnis erzeugen</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="459"/>
         <source>00000000000000000000</source>
         <translation>00000000000000000000</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="247"/>
         <source>Input format:</source>
         <translation>Eingabeformat:</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="350"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Example: &amp;quot;ZR3M5I...&amp;quot;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Beispiel: &amp;quot;ZR3M5I...&amp;quot;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="353"/>
         <source>Base32</source>
         <translation>Base32</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="366"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Exampel: &amp;quot;0xA3911C05...&amp;quot;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Beispiel: &amp;quot;0xA3911C05...&amp;quot;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="369"/>
         <source>Hex</source>
         <translation>Hexadezimal</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="402"/>
         <source>Note: 2&lt;sup&gt;nd&lt;/sup&gt; factors aren&apos;t protected against physical attacks. Change all OTP secrets in case you loose the Nitrokey.</source>
         <translation>Hinweis: Zweitfaktoren sind nicht gegen physische Angriffe geschützt. Ändern Sie alle Einmalpasswörter falls Sie den Nitrokey verlieren.</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="433"/>
         <source>Parameters</source>
         <translation>Parameter</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="440"/>
         <source>Send &apos;enter&apos; as the last keystroke</source>
         <translation>&apos;Enter&apos; als letztes Zeichen senden</translation>
     </message>
@@ -805,333 +658,238 @@ Bitte versuchen Sie es erneut</translation>
         <translation type="vanished">00000000</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="469"/>
         <source>Set to zero</source>
         <translation>Auf Null setzen</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="476"/>
         <source>Set to random</source>
         <translation>Zufällig befüllen</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="502"/>
         <source>6 digits</source>
         <translation>6 Ziffern</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="512"/>
         <source>8 digits</source>
         <translation>8 Ziffern</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="506"/>
-        <location filename="../src/ui/mainwindow.cpp" line="876"/>
-        <location filename="../src/ui/mainwindow.cpp" line="888"/>
         <source>Nitrokey disconnected</source>
         <translation>Nitrokey wurde entfernt</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="564"/>
         <source>Moving factor seed:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="571"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2084"/>
         <source>HOTP length:</source>
         <translation>HOTP-Länge:</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="578"/>
         <source>TOTP interval:</source>
         <translation>TOTP-Intervall:</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="608"/>
         <source>Token ID</source>
         <translation>Token-ID</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="620"/>
         <source>Send token ID</source>
         <translation>Token-ID senden</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="627"/>
         <source>Keyboard layout (DISABLED FEATURE):</source>
         <translation>Tastaturlayout (FUNKTION DEAKTIVIERT)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="662"/>
         <source>MUI:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="669"/>
         <source>TT:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="676"/>
         <source>OMP:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="700"/>
         <source>QWERTY</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="705"/>
         <source>QWERTZ</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="710"/>
         <source>AZERTY</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="715"/>
         <source>DVORAK</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="771"/>
-        <location filename="../ui/mainwindow.ui" line="1137"/>
-        <location filename="../ui/mainwindow.ui" line="1353"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="778"/>
-        <location filename="../ui/mainwindow.ui" line="1144"/>
-        <location filename="../ui/mainwindow.ui" line="1360"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="788"/>
         <source>OTP General</source>
         <translation>OTP Allgemein</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="812"/>
         <source>OTP Password settings</source>
         <translation>Einmalpasswort-Einstellungen</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="821"/>
         <source>Protect OTP by user PIN</source>
-        <translation>Einmalpasswörter mit Benutzer-PIN schützen</translation>
+        <translation type="vanished">Einmalpasswörter mit Benutzer-PIN schützen</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="828"/>
         <source>Forget PIN after 10 minutes</source>
-        <translation>PIN nach 10 Minuten vergessen</translation>
+        <translation type="vanished">PIN nach 10 Minuten vergessen</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="858"/>
         <source>USB-Keyboard only</source>
         <translation>Nur für USB-Tastaturen</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="869"/>
         <source>Double press NumLock:</source>
         <translation>NumLock doppelt drücken:</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="876"/>
         <source>Double press CapsLock:</source>
         <translation>CapsLock doppelt drücken:</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="883"/>
         <source>Double press ScrollLock:</source>
         <translation>ScrollLock doppelt drücken:</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="838"/>
         <source>Nitrokey Pro connected</source>
         <translation>Nitrokey Pro wurde verbunden</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="895"/>
-        <location filename="../ui/mainwindow.ui" line="914"/>
-        <location filename="../ui/mainwindow.ui" line="933"/>
         <source>Do nothing</source>
         <translation>Nichts tun</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="900"/>
-        <location filename="../ui/mainwindow.ui" line="919"/>
-        <location filename="../ui/mainwindow.ui" line="938"/>
         <source>Send HOTP1</source>
         <translation>Sende HOTP1</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="905"/>
-        <location filename="../ui/mainwindow.ui" line="924"/>
-        <location filename="../ui/mainwindow.ui" line="943"/>
         <source>Send HOTP2</source>
         <translation>Sende HOTP2</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="873"/>
-        <location filename="../src/ui/mainwindow.cpp" line="931"/>
         <source>Nitrokey Storage connected</source>
         <translation>Nitrokey Storage wurde verbunden</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="989"/>
-        <source>Tests</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="1000"/>
         <source>Number of tests:</source>
-        <translation>Anzahl der Tests:</translation>
+        <translation type="vanished">Anzahl der Tests:</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1007"/>
         <source>HOTP counter:</source>
-        <translation>HOTP-Zähler:</translation>
+        <translation type="vanished">HOTP-Zähler:</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1065"/>
-        <source>Test HOTP</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="1072"/>
-        <source>Test TOTP</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="1154"/>
-        <location filename="../src/ui/mainwindow.cpp" line="1634"/>
-        <location filename="../src/ui/mainwindow.cpp" line="1777"/>
         <source>Password Safe</source>
         <translation>Passwort-Safe</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1186"/>
         <source>Password:</source>
         <translation>Passwort:</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1196"/>
         <source>Login name:</source>
         <translation>Login-Name:</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1108"/>
         <source>&amp;OTP</source>
         <translation>&amp;Einmalpasswörter</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1210"/>
         <source>Slot name:</source>
         <translation>Namen des Eintrags:</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1111"/>
         <source>&amp;Factory reset</source>
         <translation>&amp;Zurücksetzen in Auslieferungszustand</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1114"/>
-        <location filename="../src/ui/mainwindow.cpp" line="1165"/>
         <source>&amp;Change User PIN</source>
         <translation>&amp;Benutzer-PIN ändern</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1118"/>
-        <location filename="../src/ui/mainwindow.cpp" line="1169"/>
         <source>&amp;Change Admin PIN</source>
         <translation>&amp;Administrator-PIN ändern</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1221"/>
         <source>Static password 0</source>
         <translation>statisches Passwort 0</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1229"/>
         <source>Generate random password</source>
         <translation>Zufallspasswort generieren</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1256"/>
         <source>Characters left:</source>
         <translation>Zeichen verfügbar</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1283"/>
         <source>...</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Password Safe fields support UTF8 data. It means that you can use your national characters here. Please remember however that non-English characters could take more space (up to 4 characters). The counters next to each field are to inform how much more standard English characters can given field accept.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Der Passwort-Safe unterstützt UTF8-Daten, so dass Sie beliebige Zeichensätze verwenden können. Diese benötigen jedoch mehr Speicherplatz (bis zu 4 Zeichen). Die Zähler neben den Feldern informieren Sie darüber, wieviele gewöhnliche englsiche Zeichen noch eingegeben werden können.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1333"/>
-        <location filename="../src/ui/mainwindow.cpp" line="1104"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3565"/>
         <source>Unlock password safe</source>
         <translation>Passwort-Safe entsperren</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1124"/>
-        <location filename="../src/ui/mainwindow.cpp" line="1220"/>
         <source>&amp;Debug</source>
         <translation>&amp;Fehlersuche</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1127"/>
         <source>&amp;Quit</source>
         <translation>&amp;Beenden</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1131"/>
         <source>&amp;About Nitrokey</source>
         <translation>&amp;Über Nitrokey</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1137"/>
         <source>&amp;OTP and Password safe</source>
         <translation>&amp;Einmalpasswörter und Passwort-Safe</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1140"/>
         <source>&amp;SecPassword</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1143"/>
         <source>&amp;Stick 20 Setup</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1146"/>
         <source>&amp;Unlock encrypted volume</source>
         <translation>&amp;Verschlüsseltes Volumen entsperren</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1151"/>
         <source>&amp;Lock encrypted volume</source>
         <translation>&amp;Verschlüsseltes Volumen sperren</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1156"/>
         <source>&amp;Unlock hidden volume</source>
         <translation>&amp;Verstecktes Volumen freischalten</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1161"/>
         <source>&amp;Lock hidden volume</source>
         <translation>&amp;Verstecktes Volumen sperren</translation>
     </message>
@@ -1148,17 +906,14 @@ Bitte versuchen Sie es erneut</translation>
         <translation type="obsolete">&amp;Aktualisierungs-PIN ändern</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1177"/>
         <source>&amp;Enable firmware update</source>
         <translation>&amp;Firmware-Aktualisierung aktivieren</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1181"/>
         <source>&amp;Export firmware to file</source>
         <translation>&amp;Firmware als Datei exportieren</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1188"/>
         <source>&amp;Destroy encrypted data</source>
         <translation>&amp;Verschlüsselte Daten zerstören</translation>
     </message>
@@ -1167,42 +922,34 @@ Bitte versuchen Sie es erneut</translation>
         <translation type="vanished">&amp;Schlüssel initialisieren</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1202"/>
         <source>&amp;Initialize storage with random data</source>
         <translation>&amp;Speicher mit Zufallsdaten initialisieren</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1206"/>
         <source>&amp;Get stick status</source>
         <translation>&amp;Gerätestatus</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1211"/>
         <source>&amp;Set unencrypted volume read-only</source>
         <translation>&amp;Unverschlüsseltes Volumen auf nur-Lesen setzen</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1216"/>
         <source>&amp;Set unencrypted volume read-write</source>
         <translation>&amp;Unverschlüsseltes Volumen auf Lesen/Schreiben setzen</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1223"/>
         <source>&amp;Setup hidden volume</source>
         <translation>&amp;Verstecktes Volumen einrichten</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1228"/>
         <source>&amp;Disable &apos;initialize storage with random data&apos; warning</source>
         <translation>&amp;Warnung &apos;Speicher mit Zufallsdaten initialisieren&quot; deaktivieren</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1232"/>
         <source>&amp;Setup password matrix</source>
         <translation>&amp;Passwortmatrix einrichten</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1236"/>
         <source>&amp;Lock stick hardware</source>
         <translation>&amp;Hardware sperren</translation>
     </message>
@@ -1211,84 +958,56 @@ Bitte versuchen Sie es erneut</translation>
         <translation type="vanished">&amp;Benutzer-PIN zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1244"/>
         <source>&amp;Lock Device</source>
         <translation>&amp;Gerät sperren</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1247"/>
         <source>Smartcard or SD card are not ready</source>
         <translation>Chipkarte oder Speicher sind nicht bereit</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1326"/>
         <source>Passwords</source>
         <translation>Passwörter</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1494"/>
-        <location filename="../src/ui/mainwindow.cpp" line="1799"/>
         <source>Configure</source>
         <translation>Konfigurieren</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1841"/>
         <source>Special Configure</source>
         <translation>Spezial konfigurieren</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2024"/>
         <source>TOTP length:</source>
         <translation>TOTP-Länge:</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2200"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2581"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2693"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3048"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3242"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3923"/>
-        <location filename="../src/ui/mainwindow.cpp" line="4124"/>
         <source>Admin PIN:</source>
         <translation>Administrator-PIN:</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3940"/>
         <source>Wrong Pin. Please try again.</source>
         <translation>Falsche PIN. Bitte versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2256"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2557"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2581"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2601"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2618"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2693"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3048"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3242"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3797"/>
         <source>Enter admin PIN</source>
         <translation>Administrator-PIN eingeben</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="953"/>
         <source>Warning: Encrypted volume is not secure,
 Select &quot;Initialize device&quot; option from context menu.</source>
         <translation type="unfinished">Warnung: Verschlüsseltes Volumen ist nicht sicher,
 Wählen Sie im Kontextmenü &quot;Gerät initialisieren&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1173"/>
         <source>&amp;Change Firmware Password</source>
         <translation>&amp;Firmware Passwort ändern</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1240"/>
         <source>&amp;Reset User PIN</source>
         <translation>&amp;Benutzer-PIN zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2267"/>
         <source>AES key generated</source>
         <translation>AES-Schlüssel wurde generiert</translation>
     </message>
@@ -1297,80 +1016,58 @@ Wählen Sie im Kontextmenü &quot;Gerät initialisieren&quot;.</translation>
         <translation type="obsolete">AES-Schlüssel existiert nicht!</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2338"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2416"/>
         <source>This activity locks your hidden volume. Do you want to proceed?
 To avoid data loss, please unmount the partitions before proceeding.</source>
         <translation>Diese Aktivität verriegelt Ihr verstecktes Volumen. Wollen Sie fortsetzen?
 Um Datenverlust zu vermeiden sollten Sie vor dem Fortfahren die Partitionen aushängen.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2346"/>
         <source>User pin dialog</source>
         <translation>Benutzer-PIN Dialog</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2346"/>
         <source>Enter user PIN:</source>
         <translation>Benutzer-PIN eingeben:</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2364"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2390"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2432"/>
         <source>This activity locks your encrypted volume. Do you want to proceed?
 To avoid data loss, please unmount the partitions before proceeding.</source>
         <translation>Diese Aktivität verriegelt Ihr verschlüsseltes Volumen. Wollen Sie fortsetzen?
 Um Datenverlust zu vermeiden sollten Sie vor dem Fortfahren die Partitionen aushängen.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2385"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2739"/>
         <source>Please enable the encrypted volume first.</source>
         <translation>Bitte aktivieren Sie zuerst das verschlüsselte Volumen.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2397"/>
         <source>Enter password for hidden volume</source>
         <translation>Passwort für verstecktes Volumen eingeben</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2397"/>
         <source>Enter password for hidden volume:</source>
         <translation>Passwort für verstecktes Volumen:</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2557"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2618"/>
         <source>Enter admin PIN:</source>
         <translation>Administrator-PIN eingeben:</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2577"/>
         <source>WARNING: Generating new AES keys will destroy the encrypted volumes, hidden volumes, and password safe! Continue?</source>
         <translation>WARNUNG: Die Generierung eines neuen AES-Schlüssels wird die verschlüsselten Volumen, versteckten Volumen und den Passwort-Safe zerstören! Fortfahren?</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2601"/>
         <source>Admin Pin:</source>
         <translation>Administrator-PIN:</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2657"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2673"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3773"/>
         <source>Enter user PIN</source>
         <translation>Benutzer-PIN eingeben:</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2657"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2673"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3971"/>
         <source>User PIN:</source>
         <translation>Benutzer-PIN:</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2707"/>
         <source>The selected lines must be greater then greatest password length</source>
         <translation>Die ausgewählten Zeilen müssen größer sein als die maximale Passwortlänge</translation>
     </message>
@@ -1395,125 +1092,92 @@ Dies wird alle verschlüsselten Volumen zerstören!
 Dieser Befehl benötigt für 32 GB mehr als eine Stunde.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2901"/>
         <source>Not implemented</source>
         <translation>Nicht implementiert</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2958"/>
         <source>Stick20Dialog: Wrong combobox value! </source>
         <translation>Nitrokey Storage Dialog: Falscher Combobox-Wert! </translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2979"/>
         <source>Warning: The encrypted Volume is not formatted.
 &quot;Use GParted or fdisk for this.&quot;</source>
         <translation>Warnung: Das verschlüsselte Volumen ist noch nicht formatiert.
 &quot;Dafür können Sie GParted oder fdisk verwenden.&quot;</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3061"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3681"/>
         <source>Please enter a slotname.</source>
         <translation>Bitte Namen des Eintrags eingeben.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3090"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3268"/>
         <source>Configuration successfully written.</source>
         <translation>Konfiguration erfolgreich gespeichert.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3119"/>
         <source>The name of the slot must not be empty.</source>
         <translation>Der Name des Eintrags darf nicht leer sein.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3123"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3307"/>
         <source>Error writing configuration!</source>
         <translation>Fehler beim Schreiben der Konfiguration!</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3137"/>
         <source>Nitrokey is not connected!</source>
         <translation>Nitrokey ist nicht verbunden!</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3317"/>
         <source>Nitrokey not connected!</source>
         <translation>Nitrokey ist nicht verbunden!</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3329"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3337"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3355"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3363"/>
         <source>One-time password has been copied to clipboard.</source>
         <translation>Einmalpasswort wurde in Zwischenablage kopiert.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3399"/>
         <source>WARNING: Are you sure you want to erase the slot?</source>
         <translation>WARNUNG: Wollen Sie wirklich den Eintrag löschen?</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3426"/>
         <source>Slot has been erased successfully.</source>
         <translation>Eintrag wurde erfolgreich gelöscht.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3553"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3561"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3714"/>
         <source>Slot </source>
         <translation>Eintrag </translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3623"/>
         <source>Can&apos;t clear slot.</source>
         <translation>Konnte Eintrag nicht löschen.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3625"/>
         <source>Slot is erased already.</source>
         <translation>Eintrag ist bereits gelöscht.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3693"/>
         <source>Please enter a password.</source>
         <translation>Bitte geben Sie ein Passwort ein.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3699"/>
         <source>Can&apos;t save slot. %1</source>
         <translation>Konnte Eintrag nicht löschen. %1</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="505"/>
         <source>Generate random password </source>
         <translation>zufälliges Passwort generieren </translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="432"/>
         <source>Active (debug mode)</source>
         <translation>aktiv (Fehlersuchmodus)</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="434"/>
         <source>Active</source>
         <translation>aktiv</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="851"/>
-        <location filename="../src/ui/mainwindow.cpp" line="907"/>
-        <location filename="../src/ui/mainwindow.cpp" line="4008"/>
         <source>Time is out-of-sync</source>
         <translation>Zeit ist nicht synchron</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="852"/>
-        <location filename="../src/ui/mainwindow.cpp" line="908"/>
         <source>WARNING!
 
 The time of your computer and Nitrokey are out of sync. Your computer may be configured with a wrong time or your Nitrokey may have been attacked. If an attacker or malware could have used your Nitrokey you should reset the secrets of your configured One Time Passwords. If your computer&apos;s time is wrong, please configure it correctly and reset the time of your Nitrokey.
@@ -1526,16 +1190,10 @@ Die Zeit Ihres Computers und des Nitrokey sind nicht synchron. Ihr Computer kön
 Zeit des Nitrokey zurücksetzen?</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="867"/>
-        <location filename="../src/ui/mainwindow.cpp" line="924"/>
-        <location filename="../src/ui/mainwindow.cpp" line="4024"/>
         <source>Time reset!</source>
         <translation>Zeit wurde zurückgesetzt!</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="893"/>
-        <location filename="../src/ui/mainwindow.cpp" line="894"/>
-        <location filename="../src/ui/mainwindow.cpp" line="930"/>
         <source>Nitrokey connected</source>
         <translation>Nitrokey wurde verbunden</translation>
     </message>
@@ -1546,158 +1204,118 @@ Select &quot;Initialize keys&quot;</source>
 Wählen Sie &quot;Schlüssel initialisieren&quot; aus.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="958"/>
         <source>Warning: Encrypted volume is not secure,
 Select &quot;Initialize storage with random data&quot;</source>
         <translation>Warnung: Verschlüsseltes Volumen ist nicht sicher.
 Wählen Sie &quot;Speicher mit Zufallsdaten initialisieren&quot; aus.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="994"/>
-        <location filename="../src/ui/mainwindow.cpp" line="996"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3354"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3358"/>
         <source>TOTP slot </source>
         <translation>TOTP-Eintrag</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1007"/>
-        <location filename="../src/ui/mainwindow.cpp" line="1009"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3328"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3332"/>
         <source>HOTP slot </source>
         <translation>HOTP-Eintrag </translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1076"/>
         <source>Nitrokey not connected</source>
         <translation>Nitrokey ist nicht verbunden</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1193"/>
         <source>&amp;Initialize device</source>
         <translation type="unfinished">&amp;Gerät initialisieren</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1917"/>
         <source>Counter value not copied - there was an error in conversion. Setting counter value to 0. Please retry.</source>
         <translation type="unfinished">Zähler nicht kopiert - Ein Kommunikationsfehler ist aufgetreten. Setze Zähler auf 0. Bitte versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1929"/>
         <source>Counter value not copied - Nitrokey Storage handles HOTP counter values up to 7 digits. Setting counter value to 0. Please retry.</source>
         <translation type="unfinished">Zähler nicht kopiert - Nitrokey Storage kann mit bis zu 7-stelligen HOTP-Zählern umgehen. Setze Zähler auf 0. Bitte versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2200"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3923"/>
-        <location filename="../src/ui/mainwindow.cpp" line="4124"/>
         <source>Enter card admin PIN</source>
         <translation>Administrator-PIN eingeben</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2217"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3110"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3288"/>
         <source>Wrong PIN. Please try again.</source>
         <translation>Falsche PIN. Bitte wiederholen.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2271"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3809"/>
         <source>Wrong password</source>
         <translation>Falsches Passwort</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2273"/>
         <source>Unable to create AES key</source>
         <translation>Konnte keinen AES-Schlüssel erzeugen</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2450"/>
         <source>Device has been locked</source>
         <translation type="unfinished">Gerät wurde gesperrt</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2465"/>
         <source>Enter Firmware Password</source>
         <translation type="unfinished">Geben Sie das Firmware-Passwort ein</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2465"/>
         <source>Enter Firmware Password:</source>
         <translation type="unfinished">Geben Sie das Firmware-Passwort ein:</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2847"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2861"/>
         <source>There was an error during communicating with device. Please try again.</source>
         <translation type="unfinished">Bei der Gerätekommunikation ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2886"/>
         <source>This command fills the encrypted volumes with random data and will destroy all encrypted volumes!
 It requires more than 1 hour for 32GB. Do you want to continue?</source>
         <translation type="unfinished">Dieser Befehl füllt das verschlüsselte Volumen mit Zufallswerten und zerstört alle verschlüsselten Volumen!
 Für 32 GB dauert es mehr als 1 Stunde. Wollen Sie fortsetzen?</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3023"/>
         <source>Either the password is not correct or the command execution resulted in an error. Please try again.</source>
         <translation type="unfinished">Entweder ist das Passwort falsch oder bei der Ausführung trat ein Fehler auf. Bitte versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3083"/>
         <source>(debug) Response: </source>
         <translation type="unfinished">(Fehlersuche) Antwort: </translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3706"/>
         <source>Can&apos;t save slot.</source>
         <translation>Eintrag konnte nicht gespeichert werden.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3811"/>
         <source>Unable to create new AES key</source>
         <translation>Neuer AES-Schlüssel konnte nicht erzeugt werden</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3822"/>
         <source>Can&apos;t unlock password safe.</source>
         <translation>Passwort-Safe konnte nicht freigeschaltet werden.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3827"/>
         <source>Password Safe unlocked successfully.</source>
         <translation>Passwort-Safe wurde erfolgreich freigeschaltet.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3839"/>
         <source>Password safe is not supported by this device.</source>
         <translation>Passwort-Safe wird durch dieses Gerät nicht unterstützt.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3845"/>
         <source>Wrong user password.</source>
         <translation>Falsches Benutzer-Passwort.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3862"/>
         <source>Pasword safe: Can&apos;t get password</source>
         <translation>Passwort-Safe: Konnte Passwort nicht lesen</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3874"/>
         <source>Password safe [%1]</source>
         <translation>Passwort-Safe [%1]</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3971"/>
         <source>Enter card user PIN</source>
         <translation>Benutzer-PIN eingeben</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="4009"/>
         <source>WARNING!
 
 The time of your computer and Nitrokey are out of sync.
@@ -1713,17 +1331,14 @@ Die Zeit Ihres Computers und des Nitrokey sind nicht synchron. Ihr Computer kön
 Zeit des Nitrokey zurücksetzen?</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="4047"/>
         <source>Invalid password!</source>
         <translation>Ungültiges Passwort!</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="4094"/>
         <source>Counter must be a value between 0 and %1</source>
         <translation type="unfinished">Zähler muss ein Wert zwischen 0 und %1 sein</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="4100"/>
         <source>For Nitrokey Storage counter must be a value between 0 and 9999999</source>
         <translation type="unfinished">Beim Nitrokey Storage muss der Zähler ein Wert zwischen 9999999 sein</translation>
     </message>
@@ -1743,76 +1358,78 @@ Zeit des Nitrokey zurücksetzen?</translation>
         <source>Unknown error.</source>
         <translation type="vanished">Unbekannter Fehler.</translation>
     </message>
+    <message>
+        <source>Protect OTP by user PIN (will be requested on first use each session)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Forget user PIN after 10 minutes (if unchecked user PIN will remain in memory until application exits)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Command execution failed. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>To handle this functionality application will keep your user PIN in memory. Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MatrixPasswordDialog</name>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="17"/>
         <source>Dialog</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="33"/>
         <source>0</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="49"/>
         <source>1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="65"/>
         <source>2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="81"/>
         <source>3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="97"/>
         <source>4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="113"/>
         <source>5</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="129"/>
         <source>6</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="145"/>
         <source>7</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="173"/>
         <source>8</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="189"/>
         <source>9</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="249"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="268"/>
         <source>Send data</source>
         <translation>Sende Daten</translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="281"/>
         <source>Exit</source>
         <translation>Schließen</translation>
     </message>
@@ -1820,37 +1437,30 @@ Zeit des Nitrokey zurücksetzen?</translation>
 <context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../ui/passworddialog.ui" line="20"/>
         <source>Password dialog</source>
         <translation>Passwortdialog</translation>
     </message>
     <message>
-        <location filename="../ui/passworddialog.ui" line="54"/>
         <source>Enter card password:</source>
         <translation>Passwort eingeben:</translation>
     </message>
     <message>
-        <location filename="../ui/passworddialog.ui" line="79"/>
         <source>Show password</source>
         <translation>Passwort anzeigen</translation>
     </message>
     <message>
-        <location filename="../ui/passworddialog.ui" line="92"/>
         <source>Use password matrix</source>
         <translation>Passwortmatrix verwenden</translation>
     </message>
     <message>
-        <location filename="../src/ui/passworddialog.cpp" line="204"/>
         <source>Your PIN is too long! Use not more than 30 characters.</source>
         <translation>Die eingegebene PIN ist zu lang. Verwenden Sie nicht mehr als 30 Zeichen.</translation>
     </message>
     <message>
-        <location filename="../src/ui/passworddialog.cpp" line="209"/>
         <source>Your PIN is too short. Use at least 6 characters.</source>
         <translation>Die eingegebene PIN ist zu kurz. Verwenden Sie mindestens 6 Zeichen.</translation>
     </message>
     <message>
-        <location filename="../src/ui/passworddialog.cpp" line="215"/>
         <source>Warning: Default PIN is used.
 Please change the PIN.</source>
         <translation>Warnung: Die Standard-PIN wird verwendet.
@@ -1860,101 +1470,76 @@ Bitte ändern Sie die PIN.</translation>
 <context>
     <name>PasswordSafeDialog</name>
     <message>
-        <location filename="../ui/passwordsafedialog.ui" line="14"/>
         <source>Password safe</source>
         <translation>Passwort-Safe</translation>
     </message>
     <message>
-        <location filename="../ui/passwordsafedialog.ui" line="30"/>
         <source>Send password</source>
         <translation>Passwort senden</translation>
     </message>
     <message>
-        <location filename="../ui/passwordsafedialog.ui" line="43"/>
         <source>Send loginname</source>
         <translation>Loginnamen senden</translation>
     </message>
     <message>
-        <location filename="../ui/passwordsafedialog.ui" line="56"/>
         <source>Send PW tab LN</source>
         <translation>Passwort - Tabulator - Login senden</translation>
     </message>
     <message>
-        <location filename="../ui/passwordsafedialog.ui" line="69"/>
         <source>OK</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/passwordsafedialog.ui" line="82"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/passwordsafedialog.ui" line="126"/>
         <source> Cut &amp;&amp; paste</source>
         <translation>Kopieren und einfügen</translation>
     </message>
     <message>
-        <location filename="../ui/passwordsafedialog.ui" line="139"/>
         <source> via Keyboard</source>
         <translation>mittels Tastatur</translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="62"/>
         <source>Password Safe Slot </source>
         <translation>Passwort-Safe Eintrag</translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="69"/>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="283"/>
         <source> clicked.
 Press &lt;Button&gt; to copy value to clipboard</source>
         <translation> Geklickt.
 Drücke &lt;Button&gt; um Wert in Zwischenablage zu kopieren</translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="99"/>
         <source>Can&apos;t send password chars via HID</source>
         <translation>Kann Passwort-Zeichen nicht mittels HID senden</translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="107"/>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="158"/>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="167"/>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="207"/>
         <source>Can&apos;t get password</source>
         <translation>Passwort nicht erhalten</translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="138"/>
         <source>Can&apos;t send loginname via keyboard</source>
         <translation>Konnte Loginnamen nicht mittels Tastatur senden</translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="144"/>
         <source>Can&apos;t send CR via keyboard</source>
         <translation>Konnte CR nicht mittels Tastatur senden</translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="150"/>
         <source>Can&apos;t send password via keyboard</source>
         <translation>Konnte Passwort nicht mittels Tastatur senden</translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="199"/>
         <source>Can&apos;t send loginname chars via HID</source>
         <translation>Konnte Loginnamen-Zeichen nicht mittels HID senden</translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="249"/>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="281"/>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="309"/>
         <source>PW Safe Slot </source>
         <translation>Passwort-Safe Eintrag</translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="251"/>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="311"/>
         <source> clicked.
 Press &lt;Button&gt; and set cursor to the input dialog.
 The value is send in </source>
@@ -1963,8 +1548,6 @@ Drücken Sie &lt;Button&gt; und setzen Sie den Cursor in die Eingabemaske.
 Der Wert wird gesendet in </translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="254"/>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="314"/>
         <source> seconds</source>
         <translation>Sekunden</translation>
     </message>
@@ -1972,59 +1555,48 @@ Der Wert wird gesendet in </translation>
 <context>
     <name>PinDialog</name>
     <message>
-        <location filename="../ui/pindialog.ui" line="20"/>
         <source>Password dialog</source>
         <translation>Passwort-Dialog</translation>
     </message>
     <message>
-        <location filename="../ui/pindialog.ui" line="54"/>
         <source>Enter card password:</source>
         <translation>Passwort eingeben:</translation>
     </message>
     <message>
-        <location filename="../ui/pindialog.ui" line="79"/>
         <source>Show password</source>
         <translation>Passwort anzeigen</translation>
     </message>
     <message>
-        <location filename="../ui/pindialog.ui" line="92"/>
         <source>Use password matrix</source>
         <translation>Passwortmatrix verwenden</translation>
     </message>
     <message>
-        <location filename="../ui/pindialog.ui" line="142"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/pindialog.ui" line="165"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Abbrechen</translation>
     </message>
     <message>
-        <location filename="../ui/pindialog.ui" line="181"/>
         <source>&amp;OK</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/pindialog.cpp" line="116"/>
         <source>Your PIN is too long! Use not more than 30 characters.</source>
         <translation>Die eingegebene PIN ist zu lang. Verwenden Sie nicht mehr als 30 Zeichen.</translation>
     </message>
     <message>
-        <location filename="../src/ui/pindialog.cpp" line="121"/>
         <source>Your PIN is too short. Use at least 6 characters.</source>
         <translation>Die eingegebene PIN ist zu kurz. Verwenden Sie mindestens 6 Zeichen.</translation>
     </message>
     <message>
-        <location filename="../src/ui/pindialog.cpp" line="128"/>
         <source>Warning: Default PIN is used.
 Please change the PIN.</source>
         <translation>Warnung: Die Standard-PIN wird verwendet.
 Bitte ändern Sie die PIN.</translation>
     </message>
     <message>
-        <location filename="../src/ui/pindialog.cpp" line="185"/>
         <source>Tries left: %1</source>
         <translation>Versuche möglich: %1</translation>
     </message>
@@ -2032,32 +1604,26 @@ Bitte ändern Sie die PIN.</translation>
 <context>
     <name>Stick20Dialog</name>
     <message>
-        <location filename="../ui/stick20dialog.ui" line="14"/>
         <source>Stick 2.0</source>
         <translation>Nitrokey Storage</translation>
     </message>
     <message>
-        <location filename="../ui/stick20dialog.ui" line="63"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Stick 2.0 command&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Nitrokey Storage Befehl&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/stick20dialog.ui" line="79"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Admin-PIN&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Administrator-PIN&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/stick20dialog.ui" line="92"/>
         <source>PIN</source>
         <translation>PIN</translation>
     </message>
     <message>
-        <location filename="../ui/stick20dialog.ui" line="116"/>
         <source>Show PIN</source>
         <translation>PIN anzeigen</translation>
     </message>
     <message>
-        <location filename="../ui/stick20dialog.ui" line="137"/>
         <source>Use matrix</source>
         <translation>Matrix verwenden</translation>
     </message>
@@ -2065,22 +1631,18 @@ Bitte ändern Sie die PIN.</translation>
 <context>
     <name>Stick20InfoDialog</name>
     <message>
-        <location filename="../ui/stick20infodialog.ui" line="14"/>
         <source>Device status</source>
         <translation>Gerätestatus</translation>
     </message>
     <message>
-        <location filename="../ui/stick20infodialog.ui" line="39"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20infodialog.ui" line="58"/>
         <source>OK</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20infodialog.cpp" line="49"/>
         <source>Nitrokey Storage status
 
 </source>
@@ -2092,22 +1654,18 @@ Bitte ändern Sie die PIN.</translation>
 <context>
     <name>Stick20ResponseDialog</name>
     <message>
-        <location filename="../ui/stick20responsedialog.ui" line="23"/>
         <source>Progress</source>
         <translation>Fortschritt</translation>
     </message>
     <message>
-        <location filename="../ui/stick20responsedialog.ui" line="46"/>
         <source>HeaderLabel</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20responsedialog.ui" line="61"/>
         <source>LabelProgressWheel</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20responsedialog.ui" line="116"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
@@ -2115,92 +1673,74 @@ Bitte ändern Sie die PIN.</translation>
 <context>
     <name>Stick20ResponseTask</name>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="119"/>
         <source>Wrong password</source>
         <translation>Falsches Passwort</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="193"/>
         <source>Encrypted volume unlocked successfully</source>
         <translation>Verschlüsseltes Volumen wurde erfolgreich entsperrt</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="197"/>
         <source>Encrypted volume locked successfully</source>
         <translation>Verschlüsseltes Volumen wurde erfolgreich gesperrt</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="200"/>
         <source>Hidden volume unlocked successfully</source>
         <translation>Verstecktes Volumen wurde erfolgreich entsperrt</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="203"/>
         <source>Hidden volume locked successfully</source>
         <translation>Verstecktes Volumen wurde erfolgreich gesperrt</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="206"/>
         <source>Hidden volume setup successfully</source>
         <translation>Verstecktes Volumen wurde erfolgreich eingerichtet</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="209"/>
         <source>Cleartext volume is in readonly mode</source>
         <translation>Klartext-Volumen ist im Nur-Lese-Modus</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="213"/>
         <source>Cleartext volume is in readwrite mode</source>
         <translation>Klartext-Volumen ist im Lese-Schreib-Modus</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="217"/>
         <source>Warning disabled</source>
         <translation>Warnung deaktiviert</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="221"/>
         <source>Firmware is locked</source>
         <translation>Firmware ist gesperrt</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="225"/>
         <source>Firmware exported successfully</source>
         <translation>Firmware wurde erfolgreich exportiert</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="229"/>
         <source>New keys generated successfully</source>
         <translation>Neue Schlüssel wurden erfolgreich generiert</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="237"/>
         <source>Storage successfully initialized with random data</source>
         <translation>Der Speicher wurde erfolgreich mit Zufallsdaten initialisiert. Um die Initialisierung abzuschließen, entfernen Sie das Gerät und verbinden Sie es bitte erneut.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="249"/>
         <source>Can&apos;t enable hidden volume</source>
         <translation>Verstecktes Volumen konnte nicht aktiviert werden</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="263"/>
         <source>Please enable the encrypted volume first.</source>
         <translation>Bitte aktivieren Sie zuerst das verschlüsselte Volumen.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="266"/>
         <source>Encrypted volume was not enabled, please enable the encrypted volume</source>
         <translation>Verschlüsseltes Volumen war nicht aktiv. Bitte aktivieren Sie das verschlüsselte Volumen</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="278"/>
         <source>Smartcard error, please retry the command</source>
         <translation>Chipkarten-Fehler. Bitte versuchen Sie den Befehl erneut</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="289"/>
         <source>Security bit of the device is activated.
 Firmware update is not possible.</source>
         <translation>Sicherheits-Bit des Geräts ist aktiviert.
@@ -2210,42 +1750,34 @@ Die Aktualisierung der Firmware ist daher nicht möglich.</translation>
 <context>
     <name>Stick20Setup</name>
     <message>
-        <location filename="../ui/stick20setup.ui" line="14"/>
         <source>Dialog</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20setup.ui" line="53"/>
         <source>Stick 2.0 setup</source>
         <translation>Nitrokey Storage konfigurieren</translation>
     </message>
     <message>
-        <location filename="../ui/stick20setup.ui" line="69"/>
         <source>Change admin PIN</source>
         <translation>Ändere Administrator-PIN</translation>
     </message>
     <message>
-        <location filename="../ui/stick20setup.ui" line="82"/>
         <source>Change password</source>
         <translation>Ändere Passwort</translation>
     </message>
     <message>
-        <location filename="../ui/stick20setup.ui" line="95"/>
         <source>Change matrix input</source>
         <translation>Ändere Matrix-Eingabe</translation>
     </message>
     <message>
-        <location filename="../ui/stick20setup.ui" line="108"/>
         <source>Setup hidden volume</source>
         <translation>Versteckte Volumen einrichten</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20setup.cpp" line="108"/>
         <source>The selected lines must be greater then greatest password length</source>
         <translation>Die ausgewählten Zeilen müssen größer als die maximale Passwortlänge sein</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20setup.cpp" line="159"/>
         <source>Build a new base key for the hidden volume? all data get lost</source>
         <translation>Einen neuen Basisschlüssel für die versteckten Volumen erzeugen? Alle Daten werden dabei gelöscht</translation>
     </message>
@@ -2253,7 +1785,6 @@ Die Aktualisierung der Firmware ist daher nicht möglich.</translation>
 <context>
     <name>Stick20Window</name>
     <message>
-        <location filename="../ui/stick20window.ui" line="14"/>
         <source>MainWindow</source>
         <translation>Hauptfenster</translation>
     </message>
@@ -2261,13 +1792,10 @@ Die Aktualisierung der Firmware ist daher nicht möglich.</translation>
 <context>
     <name>UpdateDialog</name>
     <message>
-        <location filename="../ui/stick20updatedialog.ui" line="14"/>
-        <location filename="../ui/stick20updatedialog.ui" line="49"/>
         <source>Firmware update</source>
         <translation>Firmware-Aktualisierung</translation>
     </message>
     <message>
-        <location filename="../ui/stick20updatedialog.ui" line="65"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When you select &amp;quot;OK&amp;quot; the device enters the &lt;br/&gt;firmware update mode. There is no way back!&lt;br/&gt;Please read the &lt;a href=&quot;https://www.nitrokey.com/en/doc/firmware-update-storage&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation &lt;/span&gt;&lt;/a&gt;how to &lt;br/&gt;update the firmware.&lt;/p&gt;&lt;p&gt;Continue entering the firmware update mode?&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wenn Sie mit &amp;quot;OK&amp;quot; bestätigen wird der Nitrokey &lt;br/&gt;in den Firmware-Aktualisierungs-Modus versetzt. Dies lässt sich nicht rückgängig machen!&lt;br/&gt;Bitte lesen Sie die &lt;a href=&quot;https://www.nitrokey.com/en/doc/firmware-update-storage&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Dokumentation &lt;/span&gt;&lt;/a&gt;um die &lt;br/&gt;Firmware zu aktualisieren.&lt;/p&gt;&lt;p&gt;Mit Firmware-Aktualisierungs-Modus fortfahren?&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -2275,7 +1803,6 @@ Die Aktualisierung der Firmware ist daher nicht möglich.</translation>
 <context>
     <name>securitydialog</name>
     <message>
-        <location filename="../ui/securitydialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Dialog</translation>
     </message>
@@ -2284,17 +1811,14 @@ Die Aktualisierung der Firmware ist daher nicht möglich.</translation>
         <translation type="obsolete">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;&gt;Sicherheitshinweis&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Bitte lesen Sie diesen Hinweis gründlich.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;PIN-Schutz&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Der Nitrokey wird durch eine Benutzer-PIN und Administrator-PIN geschützt. Die Benutzer-PIN wird zum Freischalten des verschlüsselten Speichers, des Passwort-Safes, der Chipkarte und (falls aktiviert) der Einmalpasswörter (OTP) verwendet. Einmalpasswörter sind standardmäßig nicht PIN-geschützt, da es sich hierbei um eine Zweifaktorauthentisierung handelt. Die Chipkarte wird bei jeder Eingabe der Benutzer-PIN freigeschaltet, unabhängig von der jeweiligen Funktion bei der die PIN eingegeben wird. Die Administrator-PIN wird zum Konfigurieren und zum Verwalten von Einträgen verwendet. Bitte ändern Sie die PINs im Auslieferungszustand und halten Sie diese geheim. Falls die Benutzer-PIN oder Administrator-PIN jeweils dreimal falsch eingegeben werden, oder falls die Chipkarte zurückgesetzt wird, werden alle Ihre sensiblen Daten gelöscht.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Physischer Schutz&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Alle sensiblen Daten sind verschlüsselt und gegen physische Angriffe geschützt. Dies trifft nicht auf Einmalpasswörter zu, da es sich hierbei um eine Zweifaktorauthentisierung handelt. Dies Einmalpasswörter-Geheimnisse lassen sich bei physischem Zugriff extrahieren (mittels JTAG-Schnittstelle). Um dies zu verhindern können Sie das Sicherheits-Bit des Geräts aktivieren. Dies verhindern jedoch auch die Firmwareaktualisierung.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Versteckte Volumen&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Versteckte Volumen setzen voraus, dass der Massenspeicher mit Zufallswerten initialisiert wurde. Versteckte Volumen sind mittels Benutzer-PIN und einem zusätzlichem Passwort, welches für jedes versteckte Volumen unterschiedlich ist, geschützt. Ohne die Benutzer-PIN und das Passwort kann das versteckte Volumen nicht gefunden werden und dessen Existenz weder bewiesen noch widerlegt werden. Das Passwort für das versteckte Volumen muss stark und lang genug sein um sog. Brute Force Angriffe zu widerstehen. Die versteckten Volumen werden auf einem Flash-Speicher mit integrierter Nutzungsverteilung (wear levelling) gespeichert. Dadurch könnten Informationen entstehen, die einem hochentwickeltem Angreifer die Existenz versteckter Volumen verraten.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/securitydialog.ui" line="26"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;&gt;Security Information&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please read the following carefully.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;PIN Protection&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Nitrokey is protected by both a user PIN and an admin PIN. Your user PIN can unlock the encrypted storage, password safe, smart card and (if enabled) One-Time Passwords (OTP). OTPs aren&apos;t PIN-protected by default because they are only used as a secondary factor. The smart card is unlocked whenever the user PIN is entered, regardless of the function for which the PIN is entered. The admin PIN can be used to configure settings and to add or change entries. You must change the default PINs and keep them confidential. If the user PIN and admin PIN are entered incorrectly three times each, or if the smart card has been reset to factory settings, all your sensitive data will be permanently lost.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Physical Protection&lt;/span&gt;&lt;/p&gt;&lt;p&gt;All sensitive data is encrypted and secured against physical attacks. This does not apply to One-Time Passwords (OTP) because they are only used as a secondary factor.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Hidden Volumes&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Hidden volumes require that the mass storage be initialised with random data. Hidden volumes are protected by both a user PIN and a separate password which can be different for each hidden volume. Without knowing both the user PIN and password, the hidden volume cannot be found and its existence can therefore neither be proven nor disproven. The password for the hidden volume must be strong and long enough to withstand a brute force attack. The hidden volumes are however stored on a flash storage with integrated wear levelling, meaning that information could potentially be leaked to a sophisticated attacker, thereby revealing the existence of hidden volumes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;&gt;Sicherheits-Informationen&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Bitte lesen Sie diesen Text aufmerksam.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;PIN-Schutz&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Ihr Nitrokey wird durch eine Benutzer-PIN und eine Administrator-PIN geschützt. Ihre Benutzer-PIN kann den verschlüsselten Speicher, den Passwort-Safe, die Chipkarte und (falls aktiviert) die Einmalpasswörter freischalten. Einmalpasswörter sind standardmäßig nicht PIN-geschützt da sie lediglich als zweiter Faktor dienen. Die Chipkarte wird immer bei Eingabe der Benutzer-PIN freigeschaltet, unabhängig von der Funktion für die die Benutzer-PIN eingegeben wurde. Die Administrator-PIN dient zum konfigurieren von Einstellungen und zum Hinzufügen oder Ändern von Einträgen. Sie sollten unbedingt die voreingestellten PINs ändern und geheim halten. Falls die Benutzer-PIN and die Administrator-PIN jeweils dreimal falsch eingegeben werden, oder falls die Chipkarte auf den Auslieferungszustand zurückgesetzt wird, gehen alle Ihre sensiblen Daten unwiderruflich verloren.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Physischer Schutz&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Alle sensiblen Daten sind verschlüsselt und gegen physische Angriffe geschützt. Dies gilt nicht für Einmalpasswörter, da diese lediglich als zweiter Faktor verwendet werden.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Versteckte Volumen&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Versteckte Volumen erfordern, dass der Massenspeicher mit Zufallsdaten initialisiert wird. Versteckte Volumen sind durch die Benutzer-PIN und ein separates Passwort, welches für jedes versteckte Volumen unterschiedlich sein kann, geschützt. Ohne Kenntnis der Benutzer-PIN und des Passworts kann das versteckte Volumen nicht gefunden werden und dessen Existenz kann somit weder bewiesen noch widerlegt werden. Das Passwort für das versteckte Volumen muss stark und lang genug sein um Bruteforce-Angriffen zu widerstehen. Die versteckten Volumen werden jedoch auf einem Flash-Speicher mit integriertem Wear-Levelling gespeichert, so dass möglicherweise Informationen anfallen können, die für einen hochentwickelten Angreifer die Existenz von versteckten Volumen belegen könnten.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/securitydialog.ui" line="45"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../ui/securitydialog.ui" line="61"/>
         <source>I read and understood this security warning</source>
         <translation>Ich habe diese Sicherheitswarnung gelesen und verstanden</translation>
     </message>
@@ -2302,88 +1826,70 @@ Die Aktualisierung der Firmware ist daher nicht möglich.</translation>
 <context>
     <name>stick20HiddenVolumeDialog</name>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="20"/>
         <source>Setup hidden volume</source>
         <translation>Versteckte Volumen Einrichten</translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="51"/>
         <source>Hidden volume slot 1</source>
         <translation>Verstecktes Volumen 1</translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="56"/>
         <source>Hidden volume slot 2</source>
         <translation>Verstecktes Volumen 2</translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="61"/>
         <source>Hidden volume slot 3</source>
         <translation>Verstecktes Volumen 3</translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="66"/>
         <source>Hidden volume slot 4</source>
         <translation>Verstecktes Volumen 4</translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="74"/>
         <source>High water mark</source>
         <translation>Höchster Stand</translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="91"/>
         <source>Start at % of SD size:</source>
         <translation>Start bei % des Speichers:</translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="122"/>
         <source>End at % of SD size:</source>
         <translation>Ende bei % des Speichers:</translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="157"/>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="191"/>
         <source>Password:</source>
         <translation>Passwort:</translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="164"/>
         <source>12345678901234567890</source>
         <translation>12345678901234567890</translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="174"/>
         <source>Show password</source>
         <translation>Passwort anzeigen</translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="202"/>
         <source>Entropy guess:</source>
         <translation>Zufälligkeit:</translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="209"/>
         <source> bits for random chars</source>
         <translation>Bits bei zufälligen Zeichen</translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="216"/>
         <source> for real words</source>
         <translation>bei Verwendung von Wörtern</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20hiddenvolumedialog.cpp" line="77"/>
         <source>Your password is too short. Use at least 8 characters.</source>
         <translation>Ihr Passwort ist zu kurz. Verwenden Sie mindestens 8 Zeichen.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20hiddenvolumedialog.cpp" line="82"/>
         <source>The passwords are not identical</source>
         <translation>Die Passwörter stimmen nicht überein</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20hiddenvolumedialog.cpp" line="91"/>
         <source>Wrong size of hidden volume</source>
         <translation>Falsche Größe des Versteckten Volumens</translation>
     </message>
@@ -2391,17 +1897,14 @@ Die Aktualisierung der Firmware ist daher nicht möglich.</translation>
 <context>
     <name>stick20LockFirmwareDialog</name>
     <message>
-        <location filename="../ui/stick20lockfirmwaredialog.ui" line="20"/>
         <source>Lock firmware</source>
         <translation>Firmware sperren</translation>
     </message>
     <message>
-        <location filename="../ui/stick20lockfirmwaredialog.ui" line="49"/>
         <source>Lock Firmware</source>
         <translation>Firmware sperren</translation>
     </message>
     <message>
-        <location filename="../ui/stick20lockfirmwaredialog.ui" line="65"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When you select &amp;quot;OK&amp;quot; the stick lock the firmware and close the hardware debug port.This disables any external hardware access to the data in the device (processor).&lt;/p&gt;&lt;p&gt;There is no way back! &lt;/p&gt;&lt;p&gt;After this you can&apos;t update the firmware.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wenn Sie mit &amp;quot;OK&amp;quot; bestätigen wird die Firmware und der Hardware-Anschluss zur Fehleranalyse gesperrt.Dies verhindern jeden externen Hardwarezugriff auf die Daten im Gerät (Prozessor).&lt;/p&gt;&lt;p&gt;Dieser Vorgang lässt sich nicht rückgängig machen! &lt;/p&gt;&lt;p&gt;Anschließend können Sie die Firmware nicht mehr aktualisieren.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>

--- a/i18n/nitrokey_en.ts
+++ b/i18n/nitrokey_en.ts
@@ -4,130 +4,103 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="23"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="53"/>
         <source>ICON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="64"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This application allows you to configure and use the Nitrokey Pro and Nitrokey Storage.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="79"/>
         <source>i</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="127"/>
         <source>App version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="164"/>
         <source>Firmware version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="201"/>
         <source>Card serial number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="140"/>
-        <location filename="../ui/aboutdialog.ui" line="177"/>
-        <location filename="../ui/aboutdialog.ui" line="214"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="86"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://www.nitrokey.com/start&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#c80636;&quot;&gt;Instructions and help&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="254"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="347"/>
         <source>Hidden Volume:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="486"/>
         <source>&lt;span style=&quot;color:#c80636&quot;&gt;Warning&lt;/span&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="511"/>
         <source>Stick is not secure!
 Select Init keys.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="442"/>
         <source>New SD card found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="454"/>
         <source>(Not erased with random data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="287"/>
         <source>SD ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="307"/>
         <source>Unencrypted volume:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="327"/>
         <source>Encrypted volume:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="425"/>
         <source>Password retry counters:</source>
         <translation type="unfinished">PIN retry counters:</translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="391"/>
         <source>Admin:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="398"/>
         <source>User:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="569"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-style:italic;&quot;&gt;Copyright 2016 by NitrokeyUG. &lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-style:italic;&quot;&gt;This software is licensed under the &lt;/span&gt;&lt;a href=&quot;https://www.gnu.org/licenses/&quot;&gt;&lt;span style=&quot; font-size:10pt; font-style:italic; text-decoration: underline; color:#c80636;&quot;&gt;GNU General Public License v3&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt; font-style:italic;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://nitrokey.com&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#c80636;&quot;&gt;www.nitrokey.com&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="609"/>
         <source>Detailed Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/aboutdialog.ui" line="619"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/aboutdialog.cpp" line="102"/>
         <source>
 SD card is not accessible
 
@@ -135,7 +108,6 @@ SD card is not accessible
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/aboutdialog.cpp" line="108"/>
         <source>
 Smartcard is not accessible
 
@@ -143,35 +115,27 @@ Smartcard is not accessible
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/aboutdialog.cpp" line="118"/>
         <source>No connection
 Please retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/aboutdialog.cpp" line="147"/>
         <source>READ/WRITE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/aboutdialog.cpp" line="149"/>
         <source>READ ONLY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/aboutdialog.cpp" line="153"/>
-        <location filename="../src/ui/aboutdialog.cpp" line="158"/>
         <source>Active</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/aboutdialog.cpp" line="155"/>
-        <location filename="../src/ui/aboutdialog.cpp" line="160"/>
         <source>Not active</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/aboutdialog.cpp" line="302"/>
         <source>No active Nitrokey
 
 </source>
@@ -181,32 +145,26 @@ Please retry</source>
 <context>
     <name>DebugDialog</name>
     <message>
-        <location filename="../ui/stick20debugdialog.ui" line="14"/>
         <source>Dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20debugdialog.ui" line="41"/>
         <source>Output GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20debugdialog.ui" line="54"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20debugdialog.ui" line="80"/>
         <source>Auto update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20debugdialog.ui" line="120"/>
         <source>Device Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20debugdialog.ui" line="133"/>
         <source>Device output logged via USB</source>
         <translation type="unfinished"></translation>
     </message>
@@ -214,218 +172,166 @@ Please retry</source>
 <context>
     <name>DialogChangePassword</name>
     <message>
-        <location filename="../ui/stick20changepassworddialog.ui" line="26"/>
         <source>Change user PIN</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20changepassworddialog.ui" line="59"/>
         <source>Old PIN</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20changepassworddialog.ui" line="72"/>
-        <location filename="../ui/stick20changepassworddialog.ui" line="85"/>
         <source>New PIN</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20changepassworddialog.ui" line="98"/>
         <source>Show PIN</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20changepassworddialog.ui" line="110"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;You can use upper and lower case, numbers, and special characters.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/stick20changepassworddialog.ui" line="132"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;PINs can only be tried three times and are secure against brute force guessing. A PIN of 6 or 8 digits is sufficiently long and longer or more complex PINs are usually unnecessary. The minimum length is %1 (%3 for admin) and the maximum length is %2 chars. &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;PINs can only be tried three times and are secure against brute force guessing. A PIN of 6 or 8 digits is sufficiently long and longer or more complex PINs are usually unnecessary. This rule does not apply to firmware password. The minimum length is %1 (%3 for admin) and the maximum length is %2 chars.  &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/stick20changepassworddialog.ui" line="147"/>
         <source>Retry count left:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="152"/>
         <source>Admin PIN:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="157"/>
         <source>Change Firmware Password</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="159"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="160"/>
         <source>New Firmware Password:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="86"/>
         <source>Unfortunately you have no more trials left. Please use &apos;Reset User PIN&apos; option from menu to reset password</source>
         <translation>Unfortunately you have no more trials left. Please use &apos;Reset User PIN&apos; option from menu to reset PIN</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="94"/>
         <source>Unfortunately you have no more trials left. Please check instruction how to reset Admin password.</source>
         <translation>Unfortunately you have no more trials left. Please check instruction how to reset Admin PIN.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="126"/>
         <source>Once the firmware password is forgotten the Nitrokey can&apos;t be updated or reset. Don&apos;t lose your firmware password, please.</source>
         <translation>Once the firmware password is forgotten the Nitrokey can&apos;t be updated or reset. Don&apos;t lose your firmware password, please.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="137"/>
         <source>Set User PIN</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="138"/>
         <source>Current User PIN:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="139"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="140"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="153"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="154"/>
         <source>New User PIN:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="144"/>
         <source>Set Admin PIN</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="145"/>
         <source>Current Admin PIN:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="146"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="147"/>
         <source>New Admin PIN:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="151"/>
         <source>Reset User PIN</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="158"/>
         <source>Current Firmware Password:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="161"/>
         <source>Show password</source>
         <translation>Show password</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="202"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="220"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="284"/>
         <source>There was a problem during communicating with device. Please retry.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="208"/>
         <source>Current password is not correct. Please retry.</source>
         <translation>Current PIN is not correct. Please retry.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="226"/>
         <source>New password is not correct. Please retry.</source>
         <translation>New PIN is not correct. Please retry.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="229"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="264"/>
         <source>New password is set</source>
         <translation>New PIN is set</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="257"/>
         <source>Wrong password.</source>
         <translation>Wrong PIN.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="259"/>
         <source>Couldn&apos;t change %1 password</source>
         <translation>Couldn&apos;t change %1 PIN</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="290"/>
         <source>Current Admin password is not correct. Please retry.</source>
         <translation>Current Admin PIN is not correct. Please retry.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="300"/>
         <source>There was a problem during communicating with device or new password is not correct. Please retry.</source>
         <translation>There was a problem during communicating with device or new PIN is not correct. Please retry.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="305"/>
         <source>New User password is set</source>
         <translation>New User PIN is set</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="329"/>
         <source>Wrong Admin PIN.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="331"/>
         <source>Couldn&apos;t unblock the user PIN. Error: %1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="334"/>
         <source>User PIN successfully unblocked</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="361"/>
         <source>Wrong password or there was a communication problem with the device.</source>
         <translation>Wrong firmware password or there was a communication problem with the device.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="364"/>
         <source>Password has been changed with success!</source>
         <translation>Firmware password has been changed with success!</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="374"/>
         <source>The minimum length of the old password is </source>
         <translation>The minimum length of the old PIN/password is </translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="375"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="397"/>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="409"/>
         <source> chars</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="385"/>
         <source>The new password entrys are not the same</source>
         <translation>The new PIN/password entries are not the same</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="396"/>
         <source>The maximum length of a password is </source>
         <translation>The maximum length of a PIN/password is </translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20changepassworddialog.cpp" line="408"/>
         <source>The minimum length of a password is </source>
         <translation>The minimum length of a PIN/password is </translation>
     </message>
@@ -433,66 +339,50 @@ Please retry</source>
 <context>
     <name>HOTPDialog</name>
     <message>
-        <location filename="../ui/hotpdialog.ui" line="14"/>
         <source>Dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/hotpdialog.ui" line="43"/>
-        <location filename="../src/ui/hotpdialog.cpp" line="96"/>
         <source>Your HOTP:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/hotpdialog.ui" line="56"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/hotpdialog.ui" line="69"/>
         <source>Get next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/hotpdialog.ui" line="101"/>
         <source>TOTP interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/hotpdialog.ui" line="114"/>
-        <location filename="../src/ui/hotpdialog.cpp" line="177"/>
-        <location filename="../src/ui/hotpdialog.cpp" line="181"/>
         <source>Valid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/hotpdialog.ui" line="138"/>
-        <location filename="../src/ui/hotpdialog.cpp" line="98"/>
         <source>HOTP copied to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/hotpdialog.cpp" line="97"/>
         <source>Next HOTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/hotpdialog.cpp" line="106"/>
         <source>Your TOTP:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/hotpdialog.cpp" line="107"/>
         <source>Generate TOTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/hotpdialog.cpp" line="110"/>
         <source>TOTP copied to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/hotpdialog.cpp" line="185"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
@@ -500,885 +390,630 @@ Please retry</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../ui/mainwindow.ui" line="20"/>
         <source>Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="65"/>
         <source>OTP Slot Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="89"/>
         <source>Manage slots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="98"/>
         <source>TOTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="108"/>
         <source>HOTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="144"/>
-        <location filename="../ui/mainwindow.ui" line="1236"/>
         <source>Slot:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="155"/>
         <source>HOTP slot 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="160"/>
         <source>HOTP slot 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="165"/>
         <source>TOTP slot 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="170"/>
         <source>TOTP slot 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="175"/>
         <source>TOTP slot 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="180"/>
         <source>TOTP slot 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="188"/>
-        <location filename="../ui/mainwindow.ui" line="1203"/>
         <source>Erase Slot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="195"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="235"/>
         <source>Secret key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="254"/>
-        <location filename="../ui/mainwindow.ui" line="266"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The secret is provided by your service provider you may want to login or can be configured in your local application which you may want to login to.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="257"/>
         <source>Secret Key:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="281"/>
         <source>********************************</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="296"/>
         <source>Secret copied to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="308"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide or show the secret.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="311"/>
-        <location filename="../ui/mainwindow.ui" line="1246"/>
         <source>Hide secret</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="334"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;After generating a random secret, you would need to copy it into your application or service where you want to login to.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="337"/>
         <source>Generate random secret</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="247"/>
         <source>Input format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="350"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Example: &amp;quot;ZR3M5I...&amp;quot;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="366"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Exampel: &amp;quot;0xA3911C05...&amp;quot;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="369"/>
         <source>Hex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="402"/>
         <source>Note: 2&lt;sup&gt;nd&lt;/sup&gt; factors aren&apos;t protected against physical attacks. Change all OTP secrets in case you loose the Nitrokey.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="433"/>
         <source>Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="469"/>
         <source>Set to zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="476"/>
         <source>Set to random</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="502"/>
         <source>6 digits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="512"/>
         <source>8 digits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="564"/>
         <source>Moving factor seed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="571"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2084"/>
         <source>HOTP length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="578"/>
         <source>TOTP interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="608"/>
         <source>Token ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="620"/>
         <source>Send token ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="627"/>
         <source>Keyboard layout (DISABLED FEATURE):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="662"/>
         <source>MUI:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="669"/>
         <source>TT:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="676"/>
         <source>OMP:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="700"/>
         <source>QWERTY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="705"/>
         <source>QWERTZ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="710"/>
         <source>AZERTY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="715"/>
         <source>DVORAK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="771"/>
-        <location filename="../ui/mainwindow.ui" line="1137"/>
-        <location filename="../ui/mainwindow.ui" line="1353"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="778"/>
-        <location filename="../ui/mainwindow.ui" line="1144"/>
-        <location filename="../ui/mainwindow.ui" line="1360"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="120"/>
         <source>(Recommendation: Use TOTP for web applications and HOTP for local applications)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="353"/>
         <source>Base32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="440"/>
         <source>Send &apos;enter&apos; as the last keystroke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="459"/>
         <source>00000000000000000000</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="788"/>
         <source>OTP General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="812"/>
         <source>OTP Password settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="821"/>
-        <source>Protect OTP by user PIN</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="828"/>
-        <source>Forget PIN after 10 minutes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="858"/>
         <source>USB-Keyboard only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="869"/>
         <source>Double press NumLock:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="876"/>
         <source>Double press CapsLock:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="883"/>
         <source>Double press ScrollLock:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="895"/>
-        <location filename="../ui/mainwindow.ui" line="914"/>
-        <location filename="../ui/mainwindow.ui" line="933"/>
         <source>Do nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="900"/>
-        <location filename="../ui/mainwindow.ui" line="919"/>
-        <location filename="../ui/mainwindow.ui" line="938"/>
         <source>Send HOTP1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="905"/>
-        <location filename="../ui/mainwindow.ui" line="924"/>
-        <location filename="../ui/mainwindow.ui" line="943"/>
         <source>Send HOTP2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="989"/>
-        <source>Tests</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="1000"/>
-        <source>Number of tests:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="1007"/>
-        <source>HOTP counter:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="1065"/>
-        <source>Test HOTP</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="1072"/>
-        <source>Test TOTP</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.ui" line="1154"/>
-        <location filename="../src/ui/mainwindow.cpp" line="1634"/>
-        <location filename="../src/ui/mainwindow.cpp" line="1777"/>
         <source>Password Safe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1186"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1196"/>
         <source>Login name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1210"/>
         <source>Slot name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1221"/>
         <source>Static password 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1229"/>
         <source>Generate random password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1256"/>
         <source>Characters left:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1283"/>
         <source>...</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Password Safe fields support UTF8 data. It means that you can use your national characters here. Please remember however that non-English characters could take more space (up to 4 characters). The counters next to each field are to inform how much more standard English characters can given field accept.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.ui" line="1333"/>
-        <location filename="../src/ui/mainwindow.cpp" line="1104"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3565"/>
         <source>Unlock password safe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="506"/>
-        <location filename="../src/ui/mainwindow.cpp" line="876"/>
-        <location filename="../src/ui/mainwindow.cpp" line="888"/>
         <source>Nitrokey disconnected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="838"/>
         <source>Nitrokey Pro connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="873"/>
-        <location filename="../src/ui/mainwindow.cpp" line="931"/>
         <source>Nitrokey Storage connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1108"/>
         <source>&amp;OTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1111"/>
         <source>&amp;Factory reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1114"/>
-        <location filename="../src/ui/mainwindow.cpp" line="1165"/>
         <source>&amp;Change User PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1118"/>
-        <location filename="../src/ui/mainwindow.cpp" line="1169"/>
         <source>&amp;Change Admin PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1124"/>
-        <location filename="../src/ui/mainwindow.cpp" line="1220"/>
         <source>&amp;Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1127"/>
         <source>&amp;Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1131"/>
         <source>&amp;About Nitrokey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1137"/>
         <source>&amp;OTP and Password safe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1140"/>
         <source>&amp;SecPassword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1143"/>
         <source>&amp;Stick 20 Setup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1146"/>
         <source>&amp;Unlock encrypted volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1151"/>
         <source>&amp;Lock encrypted volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1156"/>
         <source>&amp;Unlock hidden volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1161"/>
         <source>&amp;Lock hidden volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1177"/>
         <source>&amp;Enable firmware update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1181"/>
         <source>&amp;Export firmware to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1188"/>
         <source>&amp;Destroy encrypted data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1202"/>
         <source>&amp;Initialize storage with random data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1206"/>
         <source>&amp;Get stick status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1211"/>
         <source>&amp;Set unencrypted volume read-only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1216"/>
         <source>&amp;Set unencrypted volume read-write</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1223"/>
         <source>&amp;Setup hidden volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1228"/>
         <source>&amp;Disable &apos;initialize storage with random data&apos; warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1232"/>
         <source>&amp;Setup password matrix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1236"/>
         <source>&amp;Lock stick hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1173"/>
         <source>&amp;Change Firmware Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="953"/>
         <source>Warning: Encrypted volume is not secure,
 Select &quot;Initialize device&quot; option from context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1193"/>
         <source>&amp;Initialize device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1240"/>
         <source>&amp;Reset User PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1244"/>
         <source>&amp;Lock Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1247"/>
         <source>Smartcard or SD card are not ready</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1326"/>
         <source>Passwords</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1494"/>
-        <location filename="../src/ui/mainwindow.cpp" line="1799"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1841"/>
         <source>Special Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1917"/>
         <source>Counter value not copied - there was an error in conversion. Setting counter value to 0. Please retry.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1929"/>
         <source>Counter value not copied - Nitrokey Storage handles HOTP counter values up to 7 digits. Setting counter value to 0. Please retry.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2024"/>
         <source>TOTP length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2200"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3923"/>
-        <location filename="../src/ui/mainwindow.cpp" line="4124"/>
         <source>Enter card admin PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2200"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2581"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2693"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3048"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3242"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3923"/>
-        <location filename="../src/ui/mainwindow.cpp" line="4124"/>
         <source>Admin PIN:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2217"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3110"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3288"/>
         <source>Wrong PIN. Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2256"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2557"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2581"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2601"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2618"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2693"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3048"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3242"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3797"/>
         <source>Enter admin PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2267"/>
         <source>AES key generated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2338"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2416"/>
         <source>This activity locks your hidden volume. Do you want to proceed?
 To avoid data loss, please unmount the partitions before proceeding.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2346"/>
         <source>User pin dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2346"/>
         <source>Enter user PIN:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2364"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2390"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2432"/>
         <source>This activity locks your encrypted volume. Do you want to proceed?
 To avoid data loss, please unmount the partitions before proceeding.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2385"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2739"/>
         <source>Please enable the encrypted volume first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2397"/>
         <source>Enter password for hidden volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2397"/>
         <source>Enter password for hidden volume:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2450"/>
         <source>Device has been locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2465"/>
         <source>Enter Firmware Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2465"/>
         <source>Enter Firmware Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2557"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2618"/>
         <source>Enter admin PIN:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2577"/>
         <source>WARNING: Generating new AES keys will destroy the encrypted volumes, hidden volumes, and password safe! Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2601"/>
         <source>Admin Pin:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2657"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2673"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3773"/>
         <source>Enter user PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2657"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2673"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3971"/>
         <source>User PIN:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2707"/>
         <source>The selected lines must be greater then greatest password length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="4094"/>
         <source>Counter must be a value between 0 and %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="4100"/>
         <source>For Nitrokey Storage counter must be a value between 0 and 9999999</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2901"/>
         <source>Not implemented</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2958"/>
         <source>Stick20Dialog: Wrong combobox value! </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2979"/>
         <source>Warning: The encrypted Volume is not formatted.
 &quot;Use GParted or fdisk for this.&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3061"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3681"/>
         <source>Please enter a slotname.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3090"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3268"/>
         <source>Configuration successfully written.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3119"/>
         <source>The name of the slot must not be empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3123"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3307"/>
         <source>Error writing configuration!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3137"/>
         <source>Nitrokey is not connected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3317"/>
         <source>Nitrokey not connected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3329"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3337"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3355"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3363"/>
         <source>One-time password has been copied to clipboard.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3399"/>
         <source>WARNING: Are you sure you want to erase the slot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3426"/>
         <source>Slot has been erased successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3553"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3561"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3714"/>
         <source>Slot </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3623"/>
         <source>Can&apos;t clear slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3625"/>
         <source>Slot is erased already.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3693"/>
         <source>Please enter a password.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3699"/>
         <source>Can&apos;t save slot. %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="505"/>
         <source>Generate random password </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="432"/>
         <source>Active (debug mode)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="434"/>
         <source>Active</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="851"/>
-        <location filename="../src/ui/mainwindow.cpp" line="907"/>
-        <location filename="../src/ui/mainwindow.cpp" line="4008"/>
         <source>Time is out-of-sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="852"/>
-        <location filename="../src/ui/mainwindow.cpp" line="908"/>
         <source>WARNING!
 
 The time of your computer and Nitrokey are out of sync. Your computer may be configured with a wrong time or your Nitrokey may have been attacked. If an attacker or malware could have used your Nitrokey you should reset the secrets of your configured One Time Passwords. If your computer&apos;s time is wrong, please configure it correctly and reset the time of your Nitrokey.
@@ -1387,131 +1022,96 @@ Reset Nitrokey&apos;s time?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="867"/>
-        <location filename="../src/ui/mainwindow.cpp" line="924"/>
-        <location filename="../src/ui/mainwindow.cpp" line="4024"/>
         <source>Time reset!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="893"/>
-        <location filename="../src/ui/mainwindow.cpp" line="894"/>
-        <location filename="../src/ui/mainwindow.cpp" line="930"/>
         <source>Nitrokey connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="958"/>
         <source>Warning: Encrypted volume is not secure,
 Select &quot;Initialize storage with random data&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="994"/>
-        <location filename="../src/ui/mainwindow.cpp" line="996"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3354"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3358"/>
         <source>TOTP slot </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1007"/>
-        <location filename="../src/ui/mainwindow.cpp" line="1009"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3328"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3332"/>
         <source>HOTP slot </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="1076"/>
         <source>Nitrokey not connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2271"/>
-        <location filename="../src/ui/mainwindow.cpp" line="3809"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2273"/>
         <source>Unable to create AES key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2847"/>
-        <location filename="../src/ui/mainwindow.cpp" line="2861"/>
         <source>There was an error during communicating with device. Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="2886"/>
         <source>This command fills the encrypted volumes with random data and will destroy all encrypted volumes!
 It requires more than 1 hour for 32GB. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3023"/>
         <source>Either the password is not correct or the command execution resulted in an error. Please try again.</source>
         <translation>Either the PIN/password is not correct or the command execution resulted in an error. Please try again.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3083"/>
         <source>(debug) Response: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3706"/>
         <source>Can&apos;t save slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3811"/>
         <source>Unable to create new AES key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3822"/>
         <source>Can&apos;t unlock password safe.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3827"/>
         <source>Password Safe unlocked successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3839"/>
         <source>Password safe is not supported by this device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3845"/>
         <source>Wrong user password.</source>
         <translation>Wrong user PIN.</translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3862"/>
         <source>Pasword safe: Can&apos;t get password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3874"/>
         <source>Password safe [%1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3940"/>
         <source>Wrong Pin. Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="3971"/>
         <source>Enter card user PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="4009"/>
         <source>WARNING!
 
 The time of your computer and Nitrokey are out of sync.
@@ -1523,80 +1123,81 @@ Reset Nitrokey&apos;s time?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/mainwindow.cpp" line="4047"/>
         <source>Invalid password!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protect OTP by user PIN (will be requested on first use each session)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Forget user PIN after 10 minutes (if unchecked user PIN will remain in memory until application exits)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Command execution failed. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>To handle this functionality application will keep your user PIN in memory. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MatrixPasswordDialog</name>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="17"/>
         <source>Dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="33"/>
         <source>0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="49"/>
         <source>1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="65"/>
         <source>2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="81"/>
         <source>3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="97"/>
         <source>4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="113"/>
         <source>5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="129"/>
         <source>6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="145"/>
         <source>7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="173"/>
         <source>8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="189"/>
         <source>9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="249"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="268"/>
         <source>Send data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20matrixpassworddialog.ui" line="281"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1604,37 +1205,30 @@ Reset Nitrokey&apos;s time?</source>
 <context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../ui/passworddialog.ui" line="20"/>
         <source>Password dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/passworddialog.ui" line="54"/>
         <source>Enter card password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/passworddialog.ui" line="79"/>
         <source>Show password</source>
         <translation>Show PIN/password</translation>
     </message>
     <message>
-        <location filename="../ui/passworddialog.ui" line="92"/>
         <source>Use password matrix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/passworddialog.cpp" line="204"/>
         <source>Your PIN is too long! Use not more than 30 characters.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/passworddialog.cpp" line="209"/>
         <source>Your PIN is too short. Use at least 6 characters.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/passworddialog.cpp" line="215"/>
         <source>Warning: Default PIN is used.
 Please change the PIN.</source>
         <translation type="unfinished"></translation>
@@ -1643,108 +1237,81 @@ Please change the PIN.</source>
 <context>
     <name>PasswordSafeDialog</name>
     <message>
-        <location filename="../ui/passwordsafedialog.ui" line="14"/>
         <source>Password safe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/passwordsafedialog.ui" line="30"/>
         <source>Send password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/passwordsafedialog.ui" line="43"/>
         <source>Send loginname</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/passwordsafedialog.ui" line="56"/>
         <source>Send PW tab LN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/passwordsafedialog.ui" line="69"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/passwordsafedialog.ui" line="82"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/passwordsafedialog.ui" line="126"/>
         <source> Cut &amp;&amp; paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/passwordsafedialog.ui" line="139"/>
         <source> via Keyboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="62"/>
         <source>Password Safe Slot </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="69"/>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="283"/>
         <source> clicked.
 Press &lt;Button&gt; to copy value to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="99"/>
         <source>Can&apos;t send password chars via HID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="107"/>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="158"/>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="167"/>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="207"/>
         <source>Can&apos;t get password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="138"/>
         <source>Can&apos;t send loginname via keyboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="144"/>
         <source>Can&apos;t send CR via keyboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="150"/>
         <source>Can&apos;t send password via keyboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="199"/>
         <source>Can&apos;t send loginname chars via HID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="249"/>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="281"/>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="309"/>
         <source>PW Safe Slot </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="251"/>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="311"/>
         <source> clicked.
 Press &lt;Button&gt; and set cursor to the input dialog.
 The value is send in </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="254"/>
-        <location filename="../src/ui/passwordsafedialog.cpp" line="314"/>
         <source> seconds</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1752,58 +1319,47 @@ The value is send in </source>
 <context>
     <name>PinDialog</name>
     <message>
-        <location filename="../ui/pindialog.ui" line="20"/>
         <source>Password dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/pindialog.ui" line="54"/>
         <source>Enter card password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/pindialog.ui" line="79"/>
         <source>Show password</source>
         <translation>Show PIN/password</translation>
     </message>
     <message>
-        <location filename="../ui/pindialog.ui" line="92"/>
         <source>Use password matrix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/pindialog.ui" line="142"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/pindialog.ui" line="165"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/pindialog.ui" line="181"/>
         <source>&amp;OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/pindialog.cpp" line="116"/>
         <source>Your PIN is too long! Use not more than 30 characters.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/pindialog.cpp" line="121"/>
         <source>Your PIN is too short. Use at least 6 characters.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/pindialog.cpp" line="128"/>
         <source>Warning: Default PIN is used.
 Please change the PIN.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/pindialog.cpp" line="185"/>
         <source>Tries left: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1811,32 +1367,26 @@ Please change the PIN.</source>
 <context>
     <name>Stick20Dialog</name>
     <message>
-        <location filename="../ui/stick20dialog.ui" line="14"/>
         <source>Stick 2.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20dialog.ui" line="63"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Stick 2.0 command&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20dialog.ui" line="79"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Admin-PIN&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20dialog.ui" line="92"/>
         <source>PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20dialog.ui" line="116"/>
         <source>Show PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20dialog.ui" line="137"/>
         <source>Use matrix</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1844,22 +1394,18 @@ Please change the PIN.</source>
 <context>
     <name>Stick20InfoDialog</name>
     <message>
-        <location filename="../ui/stick20infodialog.ui" line="14"/>
         <source>Device status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20infodialog.ui" line="39"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20infodialog.ui" line="58"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20infodialog.cpp" line="49"/>
         <source>Nitrokey Storage status
 
 </source>
@@ -1869,22 +1415,18 @@ Please change the PIN.</source>
 <context>
     <name>Stick20ResponseDialog</name>
     <message>
-        <location filename="../ui/stick20responsedialog.ui" line="23"/>
         <source>Progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20responsedialog.ui" line="46"/>
         <source>HeaderLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20responsedialog.ui" line="61"/>
         <source>LabelProgressWheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20responsedialog.ui" line="116"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1892,92 +1434,74 @@ Please change the PIN.</source>
 <context>
     <name>Stick20ResponseTask</name>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="119"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="193"/>
         <source>Encrypted volume unlocked successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="197"/>
         <source>Encrypted volume locked successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="200"/>
         <source>Hidden volume unlocked successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="203"/>
         <source>Hidden volume locked successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="206"/>
         <source>Hidden volume setup successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="209"/>
         <source>Cleartext volume is in readonly mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="213"/>
         <source>Cleartext volume is in readwrite mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="217"/>
         <source>Warning disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="221"/>
         <source>Firmware is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="225"/>
         <source>Firmware exported successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="229"/>
         <source>New keys generated successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="237"/>
         <source>Storage successfully initialized with random data</source>
         <translation>Storage successfully initialized with random data. Please remove the device and insert again to complete initialization process.</translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="249"/>
         <source>Can&apos;t enable hidden volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="263"/>
         <source>Please enable the encrypted volume first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="266"/>
         <source>Encrypted volume was not enabled, please enable the encrypted volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="278"/>
         <source>Smartcard error, please retry the command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20-response-task.cpp" line="289"/>
         <source>Security bit of the device is activated.
 Firmware update is not possible.</source>
         <translation type="unfinished"></translation>
@@ -1986,42 +1510,34 @@ Firmware update is not possible.</source>
 <context>
     <name>Stick20Setup</name>
     <message>
-        <location filename="../ui/stick20setup.ui" line="14"/>
         <source>Dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20setup.ui" line="53"/>
         <source>Stick 2.0 setup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20setup.ui" line="69"/>
         <source>Change admin PIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20setup.ui" line="82"/>
         <source>Change password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20setup.ui" line="95"/>
         <source>Change matrix input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20setup.ui" line="108"/>
         <source>Setup hidden volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20setup.cpp" line="108"/>
         <source>The selected lines must be greater then greatest password length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20setup.cpp" line="159"/>
         <source>Build a new base key for the hidden volume? all data get lost</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2029,7 +1545,6 @@ Firmware update is not possible.</source>
 <context>
     <name>Stick20Window</name>
     <message>
-        <location filename="../ui/stick20window.ui" line="14"/>
         <source>MainWindow</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2037,13 +1552,10 @@ Firmware update is not possible.</source>
 <context>
     <name>UpdateDialog</name>
     <message>
-        <location filename="../ui/stick20updatedialog.ui" line="14"/>
-        <location filename="../ui/stick20updatedialog.ui" line="49"/>
         <source>Firmware update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20updatedialog.ui" line="65"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When you select &amp;quot;OK&amp;quot; the device enters the &lt;br/&gt;firmware update mode. There is no way back!&lt;br/&gt;Please read the &lt;a href=&quot;https://www.nitrokey.com/en/doc/firmware-update-storage&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation &lt;/span&gt;&lt;/a&gt;how to &lt;br/&gt;update the firmware.&lt;/p&gt;&lt;p&gt;Continue entering the firmware update mode?&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2051,22 +1563,18 @@ Firmware update is not possible.</source>
 <context>
     <name>securitydialog</name>
     <message>
-        <location filename="../ui/securitydialog.ui" line="14"/>
         <source>Dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/securitydialog.ui" line="26"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;&gt;Security Information&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please read the following carefully.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;PIN Protection&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Nitrokey is protected by both a user PIN and an admin PIN. Your user PIN can unlock the encrypted storage, password safe, smart card and (if enabled) One-Time Passwords (OTP). OTPs aren&apos;t PIN-protected by default because they are only used as a secondary factor. The smart card is unlocked whenever the user PIN is entered, regardless of the function for which the PIN is entered. The admin PIN can be used to configure settings and to add or change entries. You must change the default PINs and keep them confidential. If the user PIN and admin PIN are entered incorrectly three times each, or if the smart card has been reset to factory settings, all your sensitive data will be permanently lost.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Physical Protection&lt;/span&gt;&lt;/p&gt;&lt;p&gt;All sensitive data is encrypted and secured against physical attacks. This does not apply to One-Time Passwords (OTP) because they are only used as a secondary factor.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Hidden Volumes&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Hidden volumes require that the mass storage be initialised with random data. Hidden volumes are protected by both a user PIN and a separate password which can be different for each hidden volume. Without knowing both the user PIN and password, the hidden volume cannot be found and its existence can therefore neither be proven nor disproven. The password for the hidden volume must be strong and long enough to withstand a brute force attack. The hidden volumes are however stored on a flash storage with integrated wear levelling, meaning that information could potentially be leaked to a sophisticated attacker, thereby revealing the existence of hidden volumes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/securitydialog.ui" line="45"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/securitydialog.ui" line="61"/>
         <source>I read and understood this security warning</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2074,88 +1582,70 @@ Firmware update is not possible.</source>
 <context>
     <name>stick20HiddenVolumeDialog</name>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="20"/>
         <source>Setup hidden volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="51"/>
         <source>Hidden volume slot 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="56"/>
         <source>Hidden volume slot 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="61"/>
         <source>Hidden volume slot 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="66"/>
         <source>Hidden volume slot 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="74"/>
         <source>High water mark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="91"/>
         <source>Start at % of SD size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="122"/>
         <source>End at % of SD size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="157"/>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="191"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="164"/>
         <source>12345678901234567890</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="174"/>
         <source>Show password</source>
         <translation>Show password</translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="202"/>
         <source>Entropy guess:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="209"/>
         <source> bits for random chars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20hiddenvolumedialog.ui" line="216"/>
         <source> for real words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20hiddenvolumedialog.cpp" line="77"/>
         <source>Your password is too short. Use at least 8 characters.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20hiddenvolumedialog.cpp" line="82"/>
         <source>The passwords are not identical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ui/stick20hiddenvolumedialog.cpp" line="91"/>
         <source>Wrong size of hidden volume</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2163,17 +1653,14 @@ Firmware update is not possible.</source>
 <context>
     <name>stick20LockFirmwareDialog</name>
     <message>
-        <location filename="../ui/stick20lockfirmwaredialog.ui" line="20"/>
         <source>Lock firmware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20lockfirmwaredialog.ui" line="49"/>
         <source>Lock Firmware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/stick20lockfirmwaredialog.ui" line="65"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When you select &amp;quot;OK&amp;quot; the stick lock the firmware and close the hardware debug port.This disables any external hardware access to the data in the device (processor).&lt;/p&gt;&lt;p&gt;There is no way back! &lt;/p&gt;&lt;p&gt;After this you can&apos;t update the firmware.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
#150 
Merging translations from different branches causes many merge conflicts on file locations where the source text is located. To avoid it `lupdate -locations none` was applied to master branch and will be to every other ready to merge branch.
For work with QtLinguist one can reverse this effect with `lupdate -locations absolute` command.