### PR TITLE
build: set CMAKE_BUILD_TYPE only if not set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ OPTION(HAVE_LIBAPPINDICATOR "Compile support for libappindicator" YES)
 
 INCLUDE(FindPkgConfig)
 
-IF (NOT (${CMAKE_BUILD_TYPE} MATCHES Release))
+IF (NOT ${CMAKE_BUILD_TYPE})
   SET(CMAKE_BUILD_TYPE Debug) 
 ENDIF()
 MESSAGE("Build type: ${CMAKE_BUILD_TYPE}") 


### PR DESCRIPTION
Quite common setting is RelWithDebInfo, but here we allow only
Release / Debug which is not completely correct.

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>