### PR TITLE
Pack union for writing OTP slot data

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -542,7 +542,7 @@ struct WriteToOTPSlot {
     union {
         uint64_t slot_counter_or_interval;
         uint8_t slot_counter_s[8];
-    };
+    } __packed;
     uint8_t _slot_config;
     uint8_t slot_token_id[13]; /** OATH Token Identifier */
 } __packed;


### PR DESCRIPTION
Fixes #214 

Tested on Windows 8.0:
- TOTP with random secret, sizes 30, 32, 60, 6 and 8 digits, secrets equal with 3rd party results
- HOTP with RFC secret, 6 and 8 digits, secrets equal the ones in example

Qt 5.7.0, MinGW 5.3.0