### PR TITLE
Fix for issue #250: Reenable PIN remanence

### DIFF
--- a/src/GUI/Authentication.cpp
+++ b/src/GUI/Authentication.cpp
@@ -85,7 +85,7 @@ bool Authentication::authenticate(){
   return authenticationSuccess;
 }
 
-quint64 Authentication::getCurrentTime() const { return QDateTime::currentMSecsSinceEpoch(); }
+quint64 Authentication::getCurrentTime() const { return (quint64)QDateTime::currentMSecsSinceEpoch(); }
 
 void Authentication::clearTemporaryPassword(bool force){
   if (force || authenticationValidUntilTime < getCurrentTime()) {

--- a/src/GUI/Authentication.h
+++ b/src/GUI/Authentication.h
@@ -24,7 +24,7 @@ private:
     QByteArray tempPassword;
     QByteArray generateTemporaryPassword() const;
     const Type type;
-    uint getCurrentTime() const;
+    quint64 getCurrentTime() const;
 private slots:
     void clearTemporaryPassword(bool force=false);
 };


### PR DESCRIPTION
Moved a bit of code to reenable the pin remanence (still harcoded to 10 mins); changed to use a millisecond-based timestamp from a second-based timestamp for current time (which was the root of the issue)