### PR TITLE
Correct clearing of 320-bit OTP secret feature bit

### DIFF
--- a/src/libada.cpp
+++ b/src/libada.cpp
@@ -110,10 +110,14 @@ std::string libada::getCardSerial() {
 #include "hotpslot.h"
 
 void libada::on_FactoryReset(){
+  clearUserDataCache();
+}
+
+void libada::clearUserDataCache() {
+  cache_TOTP_name.clear();
+  cache_HOTP_name.clear();
   cache_PWS_name.clear();
   status_PWS.clear();
-  cache_HOTP_name.clear();
-  cache_TOTP_name.clear();
 }
 
 
@@ -264,6 +268,8 @@ bool libada::is_nkpro_07_rtm1() {
 }
 
 bool libada::is_secret320_supported() {
+  //reused atomic_int for this tri-bool
+  //TODO rewrite with enum and templated atomic<> for better clarity
   constexpr auto true_value = 1;
   constexpr auto false_value = 0;
   if (secret320_supported_cached == invalid_value){
@@ -318,10 +324,7 @@ bool libada::set_current_time() {
 
 void libada::on_DeviceDisconnect() {
   //TODO imp perf compare serial numbers to not clear cache if it is the same device
-  cache_TOTP_name.clear();
-  cache_HOTP_name.clear();
-  cache_PWS_name.clear();
-  status_PWS.clear();
+  clearUserDataCache();
   cardSerial_cached.clear();
   minor_firmware_version_cached = invalid_value;
   secret320_supported_cached = invalid_value;

--- a/src/libada.cpp
+++ b/src/libada.cpp
@@ -114,8 +114,6 @@ void libada::on_FactoryReset(){
   status_PWS.clear();
   cache_HOTP_name.clear();
   cache_TOTP_name.clear();
-  minor_firmware_version_cached = invalid_value;
-  secret320_supported_cached = invalid_value;
 }
 
 
@@ -326,6 +324,7 @@ void libada::on_DeviceDisconnect() {
   status_PWS.clear();
   cardSerial_cached.clear();
   minor_firmware_version_cached = invalid_value;
+  secret320_supported_cached = invalid_value;
 }
 
 

--- a/src/libada.h
+++ b/src/libada.h
@@ -143,6 +143,8 @@ public:
   nitrokey::proto::stick10::GetStatus::ResponsePayload get_status();
 
   bool have_communication_issues_occurred();
+
+    void clearUserDataCache();
 };
 
 


### PR DESCRIPTION
Feature bit is cached and cleared only on factory reset action and not on device disconnection. Following patch fixes that.