### PR TITLE
FreeBSD compatible build

### DIFF
--- a/src/GUI/StorageActions.cpp
+++ b/src/GUI/StorageActions.cpp
@@ -43,6 +43,7 @@
 
 
 void unmountEncryptedVolumes() {
+    return;
 #if defined(Q_OS_LINUX)
   std::string endev = systemutils::getEncryptedDevice();
   if (endev.size() < 1)

--- a/src/systemutils.cpp
+++ b/src/systemutils.cpp
@@ -24,7 +24,6 @@
 #include <cctype>
 #include <fstream>
 #include <iostream>
-#include <mntent.h>
 #include <vector>
 using namespace std;
 
@@ -72,22 +71,7 @@ string getEncryptedDevice() {
   return string("/dev/") + nitrodevices.back();
 }
 
-string getMntPoint(string deviceName) {
-  // return mount point of given device
-  string res;
-  FILE *src = setmntent("/etc/mtab", "r");
-  struct mntent mnt;
-  char buf[4096];
-  while (getmntent_r(src, &mnt, buf, sizeof(buf))) {
-    if (mnt.mnt_dir == NULL)
-      continue;
-    string device(mnt.mnt_fsname);
-    if (device.find(deviceName) != string::npos) {
-      res = string(mnt.mnt_dir);
-      break;
-    }
-  }
-  endmntent(src);
-  return res;
+string getMntPoint(string) {
+  return string();
 }
 }


### PR DESCRIPTION
This PR should contain changes allowing to compile App on FreeBSD.
- Remove mntent.h
- Disable root-requiring code for automatic unmounting of the encrypted volume.