### PR TITLE
Compile and link resources to final executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,6 @@ set(CMAKE_AUTORCC ON)
 SET(qrc_files
     resources.qrc
 )
-qt5_add_resources(RESOURCE_ADDED ${qrc_files})
 
 # create translation files to include into resource file
 # remember to add new translations files there


### PR DESCRIPTION
The resources must be manually added to final executable in order to be built and liked.

ciao

luigi