### PR TITLE
fix build with -Wcatch-value=

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1451,7 +1451,7 @@ void MainWindow::PWS_ExceClickedSlot(int Slot) {
     QString title = QString("Password has been copied to clipboard");
     tray.showTrayMessage(title, password_safe_slot_info);
   }
-  catch(DeviceCommunicationException){
+  catch(DeviceCommunicationException &e){
     tray.showTrayMessage(tr(Communication_error_message));
   }
 }


### PR DESCRIPTION
```cxx
src/ui/mainwindow.cpp: In member function 'void MainWindow::PWS_ExceClickedSlot(int)':
src/ui/mainwindow.cpp:1454:9: warning: catching polymorphic type 'class DeviceCommunicationException' by value [-Wcatch-value=]
   catch(DeviceCommunicationException){
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```