### PR TITLE
Add option --no-window; workaround for #349

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,6 +150,10 @@ int main(int argc, char *argv[]) {
     w.set_debug_level(parser.value("debug-level").toInt());
   }
 
+  if(parser.isSet("no-window")) {
+    w.hideOnStartup();
+  }
+
 
 //  csApplet()->setParent(&w);
   int retcode = -1;
@@ -296,6 +300,8 @@ bool configureParser(const QApplication &a, QCommandLineParser &parser) {
                                       "Load translation file with given name "
                                       "and store this choice in settings file."),
           "en"},
+      {"no-window",
+          QCoreApplication::translate("main", "Display no window.")},
 });
 
   parser.process(a);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -417,6 +417,22 @@ void MainWindow::closeEvent(QCloseEvent *event) {
   }
 }
 
+void MainWindow::showEvent(QShowEvent *event) {
+  if (suppress_next_show){
+    suppress_next_show = false;
+#ifdef Q_OS_MAC
+    QTimer::singleShot(0, this, SLOT(showMinimized()));
+#else
+    QTimer::singleShot(0, this, SLOT(hide()));
+#endif
+  }
+}
+
+void MainWindow::hideOnStartup()
+{
+  suppress_next_show = true;
+}
+
 void MainWindow::generateComboBoxEntrys() {
   //FIXME run in separate thread
   int i;

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -58,6 +58,7 @@ public :
 
 protected:
   void closeEvent(QCloseEvent *event) override;
+  void showEvent(QShowEvent *event) override;
 
 private:
   Q_DISABLE_COPY(MainWindow);
@@ -221,8 +222,11 @@ public:
   void set_debug_mode();
   void set_debug_level(int debug_level);
 
+  void hideOnStartup();
+
 private:
   bool debug_mode = false;
+  bool suppress_next_show = false;
 
   void showNotificationLabel();
 


### PR DESCRIPTION
If the option --no-window is given the MainWindow is closed
immediately after it is shown. I have found no better solution for this.

Disclaimer: I am by no means a C++ or QT expert.