### PR TITLE
metainfo: Move 1.4.0 release to the top

### DIFF
--- a/data/com.nitrokey.nitrokey-app.appdata.xml
+++ b/data/com.nitrokey.nitrokey-app.appdata.xml
@@ -17,8 +17,8 @@
 	  <category>Qt</category>
   </categories>
   <releases>
-	<release version="1.3.2" date="2018-08-21" />
     <release version="1.4.0" date="2019-06-25" />
+    <release version="1.3.2" date="2018-08-21" />
   </releases>
   <provides>
 	  <binary>nitrokey-app</binary>


### PR DESCRIPTION
appstream-glib does not like it this way.

Closes: https://github.com/Nitrokey/nitrokey-app/issues/438
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>