### PR TITLE
use git describe for snapcraft version

### DIFF
--- a/ci-scripts/snapcraft.sh
+++ b/ci-scripts/snapcraft.sh
@@ -5,10 +5,13 @@ set -exuo pipefail
 
 tar xf ./artifacts/${NITROKEY_APP_BUILD_ARTIFACT_VERSION}.tar.gz
 
+echo Git Version:
+echo $(git describe --always)
+
 mkdir -p artifacts
 OUTDIR="$(realpath artifacts)"
 
-OUTNAME="nitrokey-app_${NITROKEY_APP_BUILD_ARTIFACT_VERSION}_amd64.snap"
+OUTNAME="nitrokey-app_$(git describe --always)_amd64.snap"
 
 pushd ${NITROKEY_APP_BUILD_ARTIFACT_VERSION}
 
@@ -28,7 +31,7 @@ esac
 cat <<-EOF > snapcraft.yaml
   name: nitrokey-app
   base: core18
-  version: ${NITROKEY_APP_BUILD_ARTIFACT_VERSION}
+  version: $(git describe --always)
   summary: Nitrokey Application
   description: A QT GUI for managing your Nitrokey device
   confinement: strict


### PR DESCRIPTION
This fixes the snapcraft build in the CI:
 ```
 Issues while validating snapcraft.yaml: The 'version' property does not match the required schema: 'nitrokey-app-v1.5-RC2-pro-only-2.dee53012' is too long (maximum length is 32) 
 ```

The output name will not be changed.
Please keep tag names shorter than 32 characters.

