### PR TITLE
update qt from 5.5 to 5.15

### DIFF
--- a/ci-scripts/dockerfiles/nitrokey-app-appimages-agent/Dockerfile
+++ b/ci-scripts/dockerfiles/nitrokey-app-appimages-agent/Dockerfile
@@ -6,8 +6,9 @@ ENV COMPILER_NAME=gcc CXX=g++-5 CC=gcc-5 AF="-yq --no-install-suggests --no-inst
 RUN apt-get -qq update && \
 	apt-get install ${AF} software-properties-common && \
 	add-apt-repository ppa:alexlarsson/flatpak && \
+	add-apt-repository ppa:beineri/opt-qt-5.15.0-xenial -y && \
 	apt-get -qq update && \
-        apt-get install ${AF} build-essential devscripts elfutils cmake libhidapi-dev libusb-1.0-0-dev g++-5 pkg-config qt5-default qttools5-dev-tools libqt5svg5-dev libqt5concurrent5 wget git curl fuse udev snapcraft flatpak-builder \
+        apt-get install ${AF} build-essential libgl-dev qt515svg qt515base devscripts elfutils cmake libhidapi-dev libusb-1.0-0-dev g++-5 pkg-config qttools5-dev-tools libqt5svg5-dev libqt5concurrent5 wget git curl fuse udev snapcraft flatpak-builder \
 	debhelper fakeroot bash-completion && \
 	wget -c -nv -P / "https://github.com/probonopd/linuxdeployqt/releases/download/6/linuxdeployqt-6-x86_64.AppImage" && \
 	wget -c -nv -P / "https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage" && \
@@ -16,4 +17,4 @@ RUN apt-get -qq update && \
 	flatpak remote-add --if-not-exists kdeapps --from https://distribute.kde.org/kdeapps.flatpakrepo && \
 	flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && \
 	flatpak install -y flathub org.kde.Sdk//5.12 org.kde.Platform//5.12
-
+RUN mkdir -p '/usr/lib/x86_64-linux-gnu/qtchooser/' && echo "/opt/qt515/bin\n/opt/qt515/lib\n" > /usr/lib/x86_64-linux-gnu/qtchooser/default.conf


### PR DESCRIPTION
Update qt from 5.5 to 5.15 for the appimages ci-builder.
The new Docker container is already uploaded(https://git.nitrokey.com/nitrokey/nitrokey-app/container_registry/7).
Resulting build for testing can be found here: https://git.nitrokey.com/nitrokey/nitrokey-app/-/jobs/57888